### PR TITLE
Fix conda installation in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Conda install (Darwin)
         if: matrix.os == 'macos-latest'
         run: |
-          conda install numpy=1.19 xarray dask pytest pytest-cov gfortran_osx-64 liblapack
+          conda env create --file build_envs/environment_Darwin.yml
       - name: Conda install (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          conda install numpy=1.19 xarray dask pytest pytest-cov gfortran_linux-64 liblapack
+          conda env create --file build_envs/environment_Linux.yml
       - name: Install geocat-f2py
         run: |
           source build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Conda install (Darwin)
         if: matrix.os == 'macos-latest'
         run: |
-          conda env create --file build_envs/environment_Darwin.yml
+          conda env update --file build_envs/environment_Darwin.yml --prune
       - name: Conda install (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          conda env create --file build_envs/environment_Linux.yml
+          conda env update --file build_envs/environment_Linux.yml --prune
       - name: Install geocat-f2py
         run: |
           source build.sh


### PR DESCRIPTION
Our CI workflow was testing against numpy=1.19 because of the following line that handled conda installation:

`conda install numpy=1.19 xarray dask pytest pytest-cov gfortran_osx-64 liblapack`

It's modified by this PR to use our build environment files instead.