### PR TITLE
Fix the errors found in GeoCAT-comp Issue #200

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
       - name: Checkout

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.08.0" %}
+{% set version = "2022.02.0" %}
 
 package:
   name: 'geocat-f2py'

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -231,8 +231,8 @@ def linint1(fi, xo, xi=None, icycx=0, msg_py=None):
     xi = fi.coords[fi.dims[-1]]
 
     # ensure rightmost dimensions of input are not chunked
-    if fi.chunks == None:
-        fi.chunk()
+    if fi.chunks is None:
+        fi = fi.chunk()
 
     if list(fi.chunks)[-1:] != [xi.shape]:
         raise Exception("fi must be unchunked along the last dimension")
@@ -436,8 +436,8 @@ def linint2(fi, xo, yo, xi=None, yi=None, icycx=0, msg_py=None):
     yi = fi.coords[fi.dims[-2]]
 
     # ensure rightmost dimensions of input are not chunked
-    if fi.chunks == None:
-        fi.chunk()
+    if fi.chunks is None:
+        fi = fi.chunk()
 
     if list(fi.chunks)[-2:] != [yi.shape, xi.shape]:
         raise ChunkError(
@@ -622,8 +622,8 @@ def linint2pts(fi, xo, yo, icycx=False, msg_py=None, xi=None, yi=None):
     yi = fi.coords[fi.dims[-2]]
 
     # Ensure the rightmost dimension of input is not chunked
-    if fi.chunks == None:
-        fi.chunk()
+    if fi.chunks is None:
+        fi = fi.chunk()
 
     if list(fi.chunks)[-2:] != [yi.shape, xi.shape]:
         raise ChunkError(

--- a/src/geocat/f2py/rcm2points_wrapper.py
+++ b/src/geocat/f2py/rcm2points_wrapper.py
@@ -136,8 +136,8 @@ def rcm2points(lat2d, lon2d, fi, lat1d, lon1d, opt=0, msg=None, meta=False):
         ).chunk(fi_chunk)
 
     # ensure rightmost dimensions of input are not chunked
-    if fi.chunks == None:
-        fi.chunk()
+    if fi.chunks is None:
+        fi = fi.chunk()
 
     if list(fi.chunks)[-2:] != [(lat2d.shape[0],), (lat2d.shape[1],)]:
         # [(lon2d.shape[0]), (lon2d.shape[1])] could also be used

--- a/test/ncl_tests/test_rgrid2rcm.ncl
+++ b/test/ncl_tests/test_rgrid2rcm.ncl
@@ -1,0 +1,35 @@
+; Comparative test case in ncl_stable for missing values
+begin
+
+	random_setallseed(1234567890, 123456789)   ; Set random seeds to default values for repeatability;
+
+	lat2d = (/(/ 1, 2, 5/),(/1, 2, 5/),(/1, 2, 5/)/)
+	lon2d = (/(/ 1, 1, 1/),(/2, 2, 2/),(/5, 5, 5/)/)
+
+	fi = random_normal(1, 1, (/3, 3, 3/)) ; 27 point data volume normal distrobution about 1 with standard deviation of 1
+
+	fi@_FillValue = -99   ; Set missing value to -99
+
+	lat = (/1.0, 2.0, 5.0/)
+	lon = (/1.0, 2.0, 5.0/)
+
+	fo = rgrid2rcm(lat, lon, fi, lat2d, lon2d, 0)
+
+	; Set centers of data cube and data cube faces to -99 (default missing value)
+    fi_msg = fi
+	fi_msg(0,1,1)=-99
+    fi_msg(1,1,1)=-99
+    fi_msg(2,1,1)=-99
+
+	fo_msg = rgrid2rcm(lat, lon, fi_msg, lat2d, lon2d, 0)
+
+	print(lat2d)
+    print(lon2d)
+    print(fi)
+	print(fi_msg)
+    print(lat)
+    print(lon)
+    print(fo)
+	print(fo_msg)
+
+end

--- a/test/ncl_tests/test_rgrid2rcm_2.ncl
+++ b/test/ncl_tests/test_rgrid2rcm_2.ncl
@@ -1,0 +1,36 @@
+	; comparative test case in ncl_stable for missing values
+begin
+
+	random_setallseed(1234567890, 123456789) ; set random seeds to default values for repeatability;
+
+	lat2d = (/(/ 1, 3, 5, 7/), (/1, 3, 5, 7/), (/1, 3, 5, 7/)/)
+	lon2d = (/(/ 2, 2, 2, 2/), (/4, 4, 4, 4/),(/6, 6, 6, 6/)/)
+
+	fi = random_normal(1, 1, (/2, 4, 3/)) ; 24 point data volume normal distribution about 1 with standard deviation of 1
+	; fi_int = (/1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24/)
+	; fi = reshape(fi_int, (/ 2, 3, 4 /))
+
+	fi@_FillValue = -99 ; Set the missing value message to -99
+
+	lat = (/1.0, 3.0, 5.0, 7.0/)
+	lon = (/2.0, 4.0, 6.0/)
+
+	fo = rgrid2rcm(lat, lon, fi, lat2d, lon2d, 0)
+
+	; set missing values to -99 (default missing value)
+    fi_msg = fi
+	fi_msg(0,0,0)=-99
+    fi_msg(0,2,2)=-99
+
+	fo_msg = rgrid2rcm(lat, lon, fi_msg, lat2d, lon2d, 0)
+
+	print(lat2d)
+    print(lon2d)
+    print(fi)
+	print(fi_msg)
+    print(lat)
+    print(lon)
+    print(fo)
+	print(fo_msg)
+
+end

--- a/test/test_rgrid2rcm_2.py
+++ b/test/test_rgrid2rcm_2.py
@@ -1,0 +1,108 @@
+import sys
+import time
+import unittest as ut
+
+import numpy as np
+import numpy.testing as nt
+import xarray as xr
+
+# Import from directory structure if coverage test, or from installed
+# packages otherwise
+if "--cov" in str(sys.argv):
+    from src.geocat.f2py import rgrid2rcm
+else:
+    from geocat.f2py import rgrid2rcm
+
+# nominal input
+fi_nom = np.asarray([
+    1.870327, 1.872924, 2.946794, 1.98253, 1.353965, 0.8730035, 0.1410671,
+    1.877125, 1.931963, -0.1676207, 1.917912, 1.735453, -1.82497, 1.01385,
+    1.053591, 1.754721, 1.177423, 0.381366, 2.015617, 0.4975608, 2.169137,
+    0.3293635, 0.6676366, 2.691788
+]).reshape((2, 4, 3))
+
+# nan input
+fi_nan = fi_nom.copy()
+fi_nan[0, 0, 0] = np.nan
+fi_nan[0, 2, 2] = np.nan
+
+# msg input
+fi_msg = fi_nan.copy()
+fi_msg[np.isnan(fi_msg)] = -99
+
+#  grids
+lat = np.asarray([1, 3, 5, 7])
+lon = np.asarray([2, 4, 6])
+lat2d = np.asarray([1, 3, 5, 7, 1, 3, 5, 7, 1, 3, 5, 7]).reshape((3, 4))
+lon2d = np.asarray([2, 2, 2, 2, 4, 4, 4, 4, 6, 6, 6, 6]).reshape((3, 4))
+
+msg64 = fi_msg[0, 0, 0].astype(np.float64)
+msg32 = fi_msg[0, 0, 0].astype(np.float32)
+
+# Expected output
+fo_nom_expected = np.asarray([
+    1.870327, 1.98253, 0.1410671, -0.1676207, 1.872924, 1.353965, 1.877125,
+    1.917912, 2.946794, 0.8730035, 1.931963, 1.735453, -1.82497, 1.754721,
+    2.015617, 0.3293635, 1.01385, 1.177423, 0.4975608, 0.6676366, 1.053591,
+    0.381366, 2.169137, 2.691788
+]).reshape((2, 3, 4))
+
+fo_nan_expected = np.asarray([
+    1.812921, 1.98253, 0.1410671, -0.1676207, 1.872924, 1.353965, 1.877125,
+    1.917912, 2.946794, 0.8730035, np.nan, 1.735453, -1.82497, 1.754721,
+    2.015617, 0.3293635, 1.01385, 1.177423, 0.4975608, 0.6676366, 1.053591,
+    0.381366, 2.169137, 2.691788
+]).reshape((2, 3, 4))
+
+fo_msg_expected = np.asarray([
+    1.812921, 1.98253, 0.1410671, -0.1676207, 1.872924, 1.353965, 1.877125,
+    1.917912, 2.946794, 0.8730035, -99, 1.735453, -1.82497, 1.754721, 2.015617,
+    0.3293635, 1.01385, 1.177423, 0.4975608, 0.6676366, 1.053591, 0.381366,
+    2.169137, 2.691788
+]).reshape((2, 3, 4))
+
+
+# run tests
+class Test_rgrid2rcm(ut.TestCase):
+    """Test_rgrid2rcm_float64 This unit test covers the nominal, nan, and msg
+    cases of 64 bit float input for rgrid2rcm."""
+
+    def test_rgrid2rcm_float64_nom(self):
+        nt.assert_array_almost_equal(
+            fo_nom_expected,
+            rgrid2rcm(lat, lon, fi_nom.astype(np.float64), lat2d, lon2d))
+
+    def test_rgrid2rcm_float64_nan(self):
+        nt.assert_array_almost_equal(
+            fo_nan_expected,
+            rgrid2rcm(lat, lon, fi_nan.astype(np.float64), lat2d, lon2d))
+
+    def test_rgrid2rcm_float64_msg(self):
+        nt.assert_array_almost_equal(
+            fo_msg_expected,
+            rgrid2rcm(lat,
+                      lon,
+                      fi_msg.astype(np.float64),
+                      lat2d,
+                      lon2d,
+                      msg=msg64))
+
+    def test_rgrid2rcm_float32_nom(self):
+        nt.assert_array_almost_equal(
+            fo_nom_expected,
+            rgrid2rcm(lat, lon, fi_nom.astype(np.float32), lat2d, lon2d))
+
+    def test_rgrid2rcm_float32_nan(self):
+        nt.assert_array_almost_equal(
+            fo_nan_expected,
+            rgrid2rcm(lat, lon, fi_nan.astype(np.float32), lat2d, lon2d))
+
+    def test_rgrid2rcm_float32_msg(self):
+        nt.assert_array_almost_equal(
+            fo_msg_expected,
+            rgrid2rcm(lat,
+                      lon,
+                      fi_msg.astype(np.float32),
+                      lat2d,
+                      lon2d,
+                      msg=msg32))


### PR DESCRIPTION
This PR fixes the bugs found in [GeoCAT-comp](https://github.com/NCAR/geocat-comp/issues/200). Below are all things it does:

- Bumps the version to 2022.02.0 for bug-fix release
- Fixes the lack of assignment at `fi.chunk()` lines in several files
- Fixes a few other issues in rgid2rcm (by converting lat2d and lon2d to xarray and removing coords assignment at the end)
- Adds unit tests for `rgrid2rcm`

While investigating the bugs reported, some other issues with the boiler-plate were found and discussed with @anissa111 , and they will be addressed in Issue #73 