### PR TITLE
NumPy.str type depreciation warning fix.

### DIFF
--- a/src/geocat/f2py/missing_values.py
+++ b/src/geocat/f2py/missing_values.py
@@ -1,16 +1,24 @@
 import numpy as np
 
-#all missing values are represented by all 1's in their dtype, int8 would be bin_11111111 or dec_-128
+# all missing values are represented by the maximum value in their dtype,
+# int8 would be bin_01111111 or dec_127
+# unint8 would be bin_11111111 or dec_255
+# floats and complex types use max per IEEE-754
 
 msg_dtype = {
-    np.str: np.str(''),
-    np.int8: np.int8(np.iinfo(np.int8).min),
-    np.int16: np.int16(np.iinfo(np.int16).min),
-    np.int32: np.int32(np.iinfo(np.int32).min),
-    np.int64: np.int64(np.iinfo(np.int64).min),
-    np.float32: np.float32(np.finfo(np.float32).min),
-    np.float64: np.float64(np.finfo(np.float64).min),
-    np.float128: np.float128(np.finfo(np.float128).min),
+    str: str(''),
+    np.int8: np.int8(np.iinfo(np.int8).max),
+    np.int16: np.int16(np.iinfo(np.int16).max),
+    np.int32: np.int32(np.iinfo(np.int32).max),
+    np.int64: np.int64(np.iinfo(np.int64).max),
+    np.float16: np.float16(np.finfo(np.float16).max),
+    np.float32: np.float32(np.finfo(np.float32).max),
+    np.float64: np.float64(np.finfo(np.float64).max),
+    np.float128: np.float128(np.finfo(np.float128).max),
+    np.complex64: np.complex64(np.finfo(np.complex64).max),
+    np.complex128: np.complex128(np.finfo(np.complex128).max),
+    np.complex192: np.complex192(np.finfo(np.complex192).max),
+    np.complex256: np.complex256(np.finfo(np.complex256).max),
     np.uint8: np.uint8(np.iinfo(np.uint8).max),
     np.uint16: np.uint16(np.iinfo(np.uint16).max),
     np.uint32: np.uint32(np.iinfo(np.uint32).max),
@@ -19,10 +27,11 @@ msg_dtype = {
 
 # lists of classes of dtypes
 supported_dtypes = msg_dtype.keys()
-float_dtypes = [np.float32, np.float64, np.float128]
+float_dtypes = [np.float16, np.float32, np.float64, np.float128]
+complex_dtypes = [np.complex64, np.complex128, np.complex192, np.complex256]
 int_dtypes = [np.int8, np.int16, np.int32, np.int64]
 uint_dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
-string_dtypes = [np.str]
+string_dtypes = [str]
 
 
 # python to fortran
@@ -37,6 +46,8 @@ def py2fort_msg(ndarray, msg_py=None, msg_fort=None):
     if msg_py is None:
         if ndtype in float_dtypes:
             msg_py = np.nan
+        elif ndtype in complex_dtypes:
+            msg_py = np.nan + np.nan * 1j
         else:
             msg_py = msg_dtype[ndtype]
 
@@ -70,6 +81,8 @@ def fort2py_msg(ndarray, msg_fort=None, msg_py=None):
     if msg_py is None:
         if ndtype in float_dtypes:
             msg_py = np.nan
+        elif ndtype in complex_dtypes:
+            msg_py = np.nan + np.nan * 1j
         else:
             msg_py = msg_dtype[ndtype]
 

--- a/src/geocat/f2py/missing_values.py
+++ b/src/geocat/f2py/missing_values.py
@@ -8,7 +8,6 @@ import numpy as np
 msg_dtype = {
     np.complex64: np.complex64(np.finfo(np.complex64).max),
     np.complex128: np.complex128(np.finfo(np.complex128).max),
-    np.complex192: np.complex192(np.finfo(np.complex192).max),
     np.complex256: np.complex256(np.finfo(np.complex256).max),
     np.float16: np.float16(np.finfo(np.float16).max),
     np.float32: np.float32(np.finfo(np.float32).max),
@@ -26,7 +25,7 @@ msg_dtype = {
 }
 
 # lists of classes of dtypes
-complex_dtypes = [np.complex64, np.complex128, np.complex192, np.complex256]
+complex_dtypes = [np.complex64, np.complex128, np.complex256]
 float_dtypes = [np.float16, np.float32, np.float64, np.float128]
 int_dtypes = [np.int8, np.int16, np.int32, np.int64]
 uint_dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
@@ -66,7 +65,7 @@ def py2fort_msg(ndarray, msg_py=None, msg_fort=None):
 
 
 #todo: Should we force output missing value to (1) always be np.nan or (2) whatever it was given in input
-#      Current code here implements (2) while most GeoCAT-ncomp functions implemented (1) (e.g. linint2)
+#      GeoCAT-f2py implements (2) while most GeoCAT-ncomp functions implemented (1) (e.g. linint2)
 def fort2py_msg(ndarray, msg_fort=None, msg_py=None):
     msg_indices = None
     ndtype = ndarray.dtype.type

--- a/src/geocat/f2py/missing_values.py
+++ b/src/geocat/f2py/missing_values.py
@@ -6,39 +6,39 @@ import numpy as np
 # floats and complex types use max per IEEE-754
 
 msg_dtype = {
-    str: str(''),
-    np.int8: np.int8(np.iinfo(np.int8).max),
-    np.int16: np.int16(np.iinfo(np.int16).max),
-    np.int32: np.int32(np.iinfo(np.int32).max),
-    np.int64: np.int64(np.iinfo(np.int64).max),
-    np.float16: np.float16(np.finfo(np.float16).max),
-    np.float32: np.float32(np.finfo(np.float32).max),
-    np.float64: np.float64(np.finfo(np.float64).max),
-    np.float128: np.float128(np.finfo(np.float128).max),
     np.complex64: np.complex64(np.finfo(np.complex64).max),
     np.complex128: np.complex128(np.finfo(np.complex128).max),
     np.complex192: np.complex192(np.finfo(np.complex192).max),
     np.complex256: np.complex256(np.finfo(np.complex256).max),
+    np.float16: np.float16(np.finfo(np.float16).max),
+    np.float32: np.float32(np.finfo(np.float32).max),
+    np.float64: np.float64(np.finfo(np.float64).max),
+    np.float128: np.float128(np.finfo(np.float128).max),
+    np.int8: np.int8(np.iinfo(np.int8).max),
+    np.int16: np.int16(np.iinfo(np.int16).max),
+    np.int32: np.int32(np.iinfo(np.int32).max),
+    np.int64: np.int64(np.iinfo(np.int64).max),
     np.uint8: np.uint8(np.iinfo(np.uint8).max),
     np.uint16: np.uint16(np.iinfo(np.uint16).max),
     np.uint32: np.uint32(np.iinfo(np.uint32).max),
     np.uint64: np.uint64(np.iinfo(np.uint64).max),
+    str: str(''),
 }
 
 # lists of classes of dtypes
-supported_dtypes = msg_dtype.keys()
-float_dtypes = [np.float16, np.float32, np.float64, np.float128]
 complex_dtypes = [np.complex64, np.complex128, np.complex192, np.complex256]
+float_dtypes = [np.float16, np.float32, np.float64, np.float128]
 int_dtypes = [np.int8, np.int16, np.int32, np.int64]
 uint_dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
 string_dtypes = [str]
+supported_dtypes = msg_dtype.keys()
 
 
 # python to fortran
 def py2fort_msg(ndarray, msg_py=None, msg_fort=None):
     msg_indices = None
-
     ndtype = ndarray.dtype.type
+
     if ndtype not in supported_dtypes:
         raise Exception("The ndarray.dtype.type of " + np.dtype(ndtype).name +
                         " is not a supported type")
@@ -69,9 +69,9 @@ def py2fort_msg(ndarray, msg_py=None, msg_fort=None):
 #      Current code here implements (2) while most GeoCAT-ncomp functions implemented (1) (e.g. linint2)
 def fort2py_msg(ndarray, msg_fort=None, msg_py=None):
     msg_indices = None
-
     ndtype = ndarray.dtype.type
-    if ndtype not in msg_dtype.keys():
+
+    if ndtype not in supported_dtypes:
         raise Exception("The ndarray.dtype.type of " + np.dtype(ndtype).name +
                         " is not a supported type")
 

--- a/test/test_linint2.py
+++ b/test/test_linint2.py
@@ -66,7 +66,7 @@ class Test_linint2_float64(ut.TestCase):
         np.testing.assert_array_equal(fi.values, fo[..., ::2, ::2].values)
 
     def test_linint2_masked(self):
-        fi_mask = np.zeros(fi_np.shape, dtype=np.bool)
+        fi_mask = np.zeros(fi_np.shape, dtype=bool)
         fi_mask[:, :, 0, 0] = True
         fi_ma = np.ma.MaskedArray(fi_np, mask=fi_mask)
         fi = xr.DataArray(fi_ma,
@@ -115,7 +115,7 @@ class Test_linint2_float32(ut.TestCase):
         np.testing.assert_array_equal(fi.values, fo[..., ::2, ::2].values)
 
     def test_linint2_masked_float32(self):
-        fi_mask = np.zeros(fi_np.shape, dtype=np.bool)
+        fi_mask = np.zeros(fi_np.shape, dtype=bool)
         fi_mask[:, :, 0, 0] = True
         fi_ma = np.ma.MaskedArray((fi_np * 100).astype(np.float32),
                                   mask=fi_mask)
@@ -153,7 +153,7 @@ class Test_linint2_int32(ut.TestCase):
         np.testing.assert_array_equal(fi.values, fo[..., ::2, ::2].values)
 
     def test_linint2_masked_int32(self):
-        fi_mask = np.zeros(fi_np.shape, dtype=np.bool)
+        fi_mask = np.zeros(fi_np.shape, dtype=bool)
         fi_mask[:, :, 0, 0] = True
         fi_ma = np.ma.MaskedArray((fi_np * 100).astype(np.int32), mask=fi_mask)
         fi = xr.DataArray(fi_ma,
@@ -191,7 +191,7 @@ class Test_linint2_int64(ut.TestCase):
         np.testing.assert_array_equal(fi.values, fo[..., ::2, ::2].values)
 
     def test_linint2_masked_int64(self):
-        fi_mask = np.zeros(fi_np.shape, dtype=np.bool)
+        fi_mask = np.zeros(fi_np.shape, dtype=bool)
         fi_mask[:, :, 0, 0] = True
         fi_ma = np.ma.MaskedArray((fi_np * 100).astype(np.int64), mask=fi_mask)
         fi = xr.DataArray(fi_ma,


### PR DESCRIPTION
NumPy depreciated their numpy.str dtype (which empty wraps the python built in str dtype)
this removes references to that dtype, and adds support for missing numpy types to missing_values.py (float16 and all complex dtypes)