### PR TITLE
Apply boilerplate improvements for the functions that don't have them

### DIFF
--- a/src/geocat/f2py/dpres_plevel_wrapper.py
+++ b/src/geocat/f2py/dpres_plevel_wrapper.py
@@ -158,7 +158,9 @@ def _dpres_plevel(plev, psfc, ptop, msg_py):
     return dp
 
 
-# TODO: WIll revisit this after merging sanity check module to repo.
+# Helper function that checks the validity of the input
+
+
 def _validity_check(pressure_levels, pressure_surface, pressure_top):
     # ''' Basic validity checks
     is_input_xr = True

--- a/src/geocat/f2py/dpres_plevel_wrapper.py
+++ b/src/geocat/f2py/dpres_plevel_wrapper.py
@@ -5,8 +5,8 @@ from .errors import AttributeError, DimensionError, MetaError
 from .fortran import dpresplvl
 from .missing_values import fort2py_msg, py2fort_msg
 
-# Single Wrapper <funcname>()
-# These Wrappers are excecuted in the __main__ python process, and should be
+# Outer Wrapper <funcname>()
+# This wrapper is excecuted in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
 
@@ -122,10 +122,9 @@ def dpres_plevel(pressure_levels,
     return dp
 
 
-# Inner Wrapper _<funcname>()
-# This wrapper basically calls the Fortran function. It also handles
-# transpose of the input and output data as well as missing value
-# representations before and after the Fortran function call.
+# Fortran Wrapper _<funcname>()
+# This wrapper is executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _dpres_plevel(plev, psfc, ptop, msg_py):

--- a/src/geocat/f2py/fortran/rcm2points.pyf
+++ b/src/geocat/f2py/fortran/rcm2points.pyf
@@ -5,21 +5,21 @@ python module rcm2points ! in
     interface  ! in :rcm2points
 	! signature : fo = drcm2points(yi, xi, fi, yo, xo, [xmsg, opt])
         subroutine drcm2points(ngrd,nyi,nxi,yi,xi,fi,nxyo,yo,xo,fo,xmsg,opt,ncrit,kval,ier) ! in :rcm2points:rcm2points.f
-            integer,            depend(fi),					                    intent(hide)	:: ngrd=shape(fi,2)
-            integer,            depend(yi),					                    intent(hide)	:: nyi=shape(yi,1)
-            integer,            depend(yi),					                    intent(hide)	:: nxi=shape(yi,0)
-            double precision,	dimension(nxi,nyi),			                    intent(in)	    :: yi
-            double precision,	dimension(nxi,nyi),depend(nxi,nyi),		        intent(in)	    :: xi
-            double precision,	dimension(nxi,nyi,ngrd),depend(nxi,nyi),	    intent(in)	    :: fi
-            integer,            depend(yo), 					                intent(hide)	:: nxyo=len(yo)
-            double precision,	dimension(nxyo),	 			                intent(in)	    :: yo
-            double precision,	dimension(nxyo),depend(nxyo),	 		        intent(in)	    :: xo
-            double precision,	dimension(nxyo,ngrd),depend(nxyo,ngrd),		    intent(out) 	:: fo(nxyo,ngrd)
-            double precision,	optional,					                    intent(in)	    :: xmsg=-99
-            integer,		optional,					                        intent(in)	    :: opt=0
-            integer,		optional,					                        intent(hide)	:: ncrit
-            integer,		optional,					                        intent(hide)	:: kval
-            integer,		optional,					                        intent(hide)	:: ier=0
+            integer,            depend(fi),                               intent(hide)  :: ngrd=shape(fi,2)
+            integer,            depend(yi),                               intent(hide)  :: nyi=shape(yi,1)
+            integer,            depend(yi),                               intent(hide)  :: nxi=shape(yi,0)
+            double precision,	dimension(nxi,nyi),                       intent(in)    :: yi
+            double precision,	dimension(nxi,nyi),depend(nxi,nyi),       intent(in)    :: xi
+            double precision,	dimension(nxi,nyi,ngrd),depend(nxi,nyi),  intent(in)    :: fi
+            integer,            depend(yo),                               intent(hide)  :: nxyo=len(yo)
+            double precision,	dimension(nxyo),                          intent(in)    :: yo
+            double precision,	dimension(nxyo),depend(nxyo),             intent(in)    :: xo
+            double precision,	dimension(nxyo,ngrd),depend(nxyo,ngrd),   intent(out)   :: fo(nxyo,ngrd)
+            double precision,	optional,                                 intent(in)    :: xmsg=-99
+            integer,            optional,                                 intent(in)    :: opt=0
+            integer,            optional,                                 intent(hide)  :: ncrit
+            integer,            optional,                                 intent(hide)  :: kval
+            integer,            optional,                                 intent(hide)  :: ier=0
         end subroutine drcm2points
     end interface 
 end python module rcm2points

--- a/src/geocat/f2py/fortran/rcm2points.pyf
+++ b/src/geocat/f2py/fortran/rcm2points.pyf
@@ -5,21 +5,21 @@ python module rcm2points ! in
     interface  ! in :rcm2points
 	! signature : fo = drcm2points(yi, xi, fi, yo, xo, [xmsg, opt])
         subroutine drcm2points(ngrd,nyi,nxi,yi,xi,fi,nxyo,yo,xo,fo,xmsg,opt,ncrit,kval,ier) ! in :rcm2points:rcm2points.f
-            integer,            depend(fi),					intent(hide)	:: ngrd=1 ! shape(fi,2)
-            integer,            depend(yi),					intent(hide)	:: nyi=shape(yi,1)
-            integer,            depend(yi),					intent(hide)	:: nxi=shape(yi,0)
-            double precision,	dimension(nxi,nyi),				intent(in)	:: yi
-            double precision,	dimension(nxi,nyi),depend(nxi,nyi),		intent(in)	:: xi
-            double precision,	dimension(nxi,nyi,ngrd),depend(nxi,nyi,ngrd),	intent(in)	:: fi
-            integer,            depend(yo), 					intent(hide)	:: nxyo=len(yo)
-            double precision,	dimension(nxyo),	 			intent(in)	:: yo
-            double precision,	dimension(nxyo),depend(nxyo),	 		intent(in)	:: xo
-            double precision,	dimension(nxyo,ngrd),depend(nxyo,ngrd),		intent(out) 	:: fo(nxyo,ngrd)
-            double precision,	optional,					intent(in)	:: xmsg=-99
-            integer,		optional,					intent(in)	:: opt=0
-            integer,		optional,					intent(hide)	:: ncrit
-            integer,		optional,					intent(hide)	:: kval
-            integer,		optional,					intent(hide)	:: ier=0
+            integer,            depend(fi),					                    intent(hide)	:: ngrd=shape(fi,2)
+            integer,            depend(yi),					                    intent(hide)	:: nyi=shape(yi,1)
+            integer,            depend(yi),					                    intent(hide)	:: nxi=shape(yi,0)
+            double precision,	dimension(nxi,nyi),			                    intent(in)	    :: yi
+            double precision,	dimension(nxi,nyi),depend(nxi,nyi),		        intent(in)	    :: xi
+            double precision,	dimension(nxi,nyi,ngrd),depend(nxi,nyi),	    intent(in)	    :: fi
+            integer,            depend(yo), 					                intent(hide)	:: nxyo=len(yo)
+            double precision,	dimension(nxyo),	 			                intent(in)	    :: yo
+            double precision,	dimension(nxyo),depend(nxyo),	 		        intent(in)	    :: xo
+            double precision,	dimension(nxyo,ngrd),depend(nxyo,ngrd),		    intent(out) 	:: fo(nxyo,ngrd)
+            double precision,	optional,					                    intent(in)	    :: xmsg=-99
+            integer,		optional,					                        intent(in)	    :: opt=0
+            integer,		optional,					                        intent(hide)	:: ncrit
+            integer,		optional,					                        intent(hide)	:: kval
+            integer,		optional,					                        intent(hide)	:: ier=0
         end subroutine drcm2points
     end interface 
 end python module rcm2points

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -8,9 +8,9 @@ from .errors import ChunkError, CoordinateError
 from .fortran import dlinint1, dlinint2, dlinint2pts
 from .missing_values import fort2py_msg, py2fort_msg
 
-# Dask Wrappers _<funcname>()
-# These Wrapper are executed within dask processes, and should do anything that
-# can benefit from parallel excution.
+# Fortran Wrappers _<funcname>()
+# These wrappers are executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _linint1(xi, fi, xo, icycx, msg_py, shape):

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -288,11 +288,11 @@ def linint2(fi: supported_types,
             xi: supported_types = None,
             yi: supported_types = None,
             icycx: bool = 0,
-            msg_py: np.number = None):
+            msg_py: np.number = None) -> supported_types:
     """Interpolates a regular grid to a rectilinear one using bi-linear
-    interpolation. The input grid may be cyclic in the x direction. The
-    interpolation is first performed in the x direction, and then in the y
-    direction.
+    interpolation. The input grid may be cyclic in the x-direction. The
+    interpolation is first performed in the x-direction, and then in the
+    y-direction.
 
     Parameters
     ----------

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -286,6 +286,8 @@ def linint1(fi: supported_types,
     return fo
 
 
+# TODO: This function requires the input to have the coordinates in the rightmost two dimensions,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def linint2(fi: supported_types,
             xo: supported_types,
             yo: supported_types,
@@ -494,6 +496,8 @@ def linint2(fi: supported_types,
     return fo
 
 
+# TODO: This function requires the input to have the coordinates in the rightmost two dimensions,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def linint2pts(fi: supported_types,
                xo: supported_types,
                yo: supported_types,

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -207,13 +207,18 @@ def linint1(fi: supported_types,
     """
 
     # ''' Start of boilerplate
+    is_input_xr = True
+
+    # If the input is numpy.ndarray, convert it to xarray.DataArray
     if not isinstance(fi, xr.DataArray):
         if (xi is None):
             raise CoordinateError(
                 "linint2: Argument xi must be provided explicitly unless fi is an xarray.DataArray."
             )
 
-        fi = xr.DataArray(fi,)
+        is_input_xr = False
+
+        fi = xr.DataArray(fi)
         fi_chunk = dict([(k, v) for (k, v) in zip(list(fi.dims), list(fi.shape))
                         ])
 
@@ -277,112 +282,104 @@ def linint1(fi: supported_types,
     return fo
 
 
-def linint2(fi, xo, yo, xi=None, yi=None, icycx=0, msg_py=None):
+def linint2(fi: supported_types,
+            xo: supported_types,
+            yo: supported_types,
+            xi: supported_types = None,
+            yi: supported_types = None,
+            icycx: bool = 0,
+            msg_py: np.number = None):
     """Interpolates a regular grid to a rectilinear one using bi-linear
-    interpolation.
-    linint2 uses bilinear interpolation to interpolate from one
-    rectilinear grid to another. The input grid may be cyclic in the x
-    direction. The interpolation is first performed in the x direction,
-    and then in the y direction.
+    interpolation. The input grid may be cyclic in the x direction. The
+    interpolation is first performed in the x direction, and then in the y
+    direction.
+
     Parameters
     ----------
-    fi : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        An array of two or more dimensions. If xi is passed in as an
-        argument, then the size of the rightmost dimension of fi
-        must match the rightmost dimension of xi. Similarly, if yi
-        is passed in as an argument, then the size of the second-
-        rightmost dimension of fi must match the rightmost dimension
-        of yi.
-        If missing values are present, then linint2 will perform the
-        bilinear interpolation at all points possible, but will
-        return missing values at coordinates which could not be
-        used.
+
+    fi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        An array of two or more dimensions. If `xi` is passed in as an argument, then the size of the
+        rightmost dimension of `fi` must match the rightmost dimension of `xi`. Similarly, if `yi` is
+        passed in as an argument, then the size of the second-rightmost dimension of `fi` must match
+        the rightmost dimension of `yi`.
+
+        If missing values are present, then linint2 will perform the bilinear interpolation at all
+        points possible, but will return missing values at coordinates which could not be used.
+
         Note:
-            This variable must be
-            supplied as a :class:`xarray.DataArray` in order to copy
-            the dimension names to the output. Otherwise, default
-            names will be used.
-    xo : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the X coordinates of
-        the return array. It must be strictly monotonically
-        increasing, but may be unequally spaced.
-        For geo-referenced data, xo is generally the longitude
-        array.
-        If the output coordinates (xo) are outside those of the
-        input coordinates (xi), then the fo values at those
-        coordinates will be set to missing (i.e. no extrapolation is
-        performed).
-    yo : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the Y coordinates of
-        the return array. It must be strictly monotonically
-        increasing, but may be unequally spaced.
-        For geo-referenced data, yo is generally the latitude array.
-        If the output coordinates (yo) are outside those of the
-        input coordinates (yi), then the fo values at those
-        coordinates will be set to missing (i.e. no extrapolation is
-        performed).
-    xi (:class:`numpy.ndarray`):
-        An array that specifies the X coordinates of the fi array.
-        Most frequently, this is a 1D strictly monotonically
-        increasing array that may be unequally spaced. In some
-        cases, xi can be a multi-dimensional array (see next
-        paragraph). The rightmost dimension (call it nxi) must have
-        at least two elements, and is the last (fastest varying)
-        dimension of fi.
-        If xi is a multi-dimensional array, then each nxi subsection
-        of xi must be strictly monotonically increasing, but may be
-        unequally spaced. All but its rightmost dimension must be
-        the same size as all but fi's rightmost two dimensions.
-        For geo-referenced data, xi is generally the longitude
-        array.
+            This variable must be supplied as a :class:`xarray.DataArray` in order to copy the
+            dimension names to the output. Otherwise, default names will be used.
+
+    xo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the X-coordinates of the return array. It must be
+        strictly monotonically increasing, but may be unequally spaced. For geo-referenced data,
+        `xo` is generally the longitude array.
+
+        If the output coordinates (xo) are outside those of the input coordinates (xi), then the `fo`
+        values at those coordinates will be set to missing (i.e. no extrapolation is performed).
+
+    yo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the Y coordinates of the return array. It must be
+        strictly monotonically increasing, but may be unequally spaced. For geo-referenced data,
+        `yo` is generally the latitude array.
+
+        If the output coordinates (yo) are outside those of the input coordinates (yi), then the `fo`
+        values at those coordinates will be set to missing (i.e. no extrapolation is performed).
+
+    xi : :class:`numpy.ndarray`:
+        An array that specifies the X-coordinates of the `fi` array. Most frequently, this is a
+        1D strictly monotonically increasing array that may be unequally spaced. In some cases, `xi`
+        can be a multi-dimensional array (see next paragraph). The rightmost dimension (call it
+        nxi) must have at least two elements, and is the last (fastest varying) dimension of `fi`.
+
+        If `xi` is a multi-dimensional array, then each nxi subsection of `xi` must be strictly
+        monotonically increasing, but may be unequally spaced. All but its rightmost dimension
+        must be the same size as all but `fi`'s rightmost two dimensions. For geo-referenced data,
+        `xi` is generally the longitude array.
+
         Note:
-            If fi is of type :class:`xarray.DataArray` and xi is
-            left unspecified, then the rightmost coordinate
-            dimension of fi will be used. If fi is not of type
-            :class:`xarray.DataArray`, then xi becomes a mandatory
-            parameter. This parameter must be specified as a keyword
-            argument.
-    yi (:class:`numpy.ndarray`):
-        An array that specifies the Y coordinates of the fi array.
-        Most frequently, this is a 1D strictly monotonically
-        increasing array that may be unequally spaced. In some
-        cases, yi can be a multi-dimensional array (see next
-        paragraph). The rightmost dimension (call it nyi) must have
-        at least two elements, and is the second-to-last dimension
-        of fi.
-        If yi is a multi-dimensional array, then each nyi subsection
-        of yi must be strictly monotonically increasing, but may be
-        unequally spaced. All but its rightmost dimension must be
-        the same size as all but fi's rightmost two dimensions.
-        For geo-referenced data, yi is generally the latitude array.
+            If `fi` is of type :class:`xarray.DataArray` and `xi` is left unspecified, then the
+            rightmost coordinate dimension of `fi` will be used. If `fi` is not of type
+            :class:`xarray.DataArray`, then `xi` becomes a mandatory parameter. This parameter
+            must be specified as a keyword argument.
+
+    yi :class:`numpy.ndarray`:
+        An array that specifies the Y-coordinates of the `fi` array. Most frequently, this is a
+        1D strictly monotonically increasing array that may be unequally spaced. In some cases,
+        `yi` can be a multi-dimensional array (see next paragraph). The rightmost dimension (call
+        it nyi) must have at least two elements, and is the second-to-last dimension of `fi`.
+
+        If `yi` is a multi-dimensional array, then each nyi subsection of `yi` must be strictly
+        monotonically increasing, but may be unequally spaced. All but its rightmost dimension must
+        be the same size as all but `fi`'s rightmost two dimensions. For geo-referenced data, `yi`
+        is generally the latitude array.
+
         Note:
-            If fi is of type :class:`xarray.DataArray` and xi is
-            left unspecified, then the second-to-rightmost
-            coordinate dimension of fi will be used. If fi is not of
-            type :class:`xarray.DataArray`, then xi becomes a
-            mandatory parameter. This parameter must be specified as
-            a keyword argument.
+            If `fi` is of type :class:`xarray.DataArray` and `xi` is left unspecified, then the
+            second-to-rightmost coordinate dimension of `fi` will be used. If `fi` is not of type
+            :class:`xarray.DataArray`, then `xi` becomes a mandatory parameter. This parameter must
+            be specified as a keyword argument.
+
     icycx : :obj:`bool`:
-        An option to indicate whether the rightmost dimension of fi
-        is cyclic. This should be set to True only if you have
-        global data, but your longitude values don't quite wrap all
-        the way around the globe. For example, if your longitude
-        values go from, say, -179.75 to 179.75, or 0.5 to 359.5,
-        then you would set this to True.
+        An option to indicate whether the rightmost dimension of `fi` is cyclic. This should be set
+        to True only if you have global data, but your longitude values don't quite wrap all the way
+        around the globe. For example, if your longitude values go from, say, -179.75 to 179.75, or
+        0.5 to 359.5, then you would set this to True.
+
     msg_py : :obj:`numpy.number`:
-        A numpy scalar value that represent a missing value in fi.
-        This argument allows a user to use a missing value scheme
-        other than NaN or masked arrays, similar to what NCL allows.
+        A numpy scalar value that represent a missing value in `fi`. This argument allows a user to
+        use a missing value scheme other than NaN or masked arrays, similar to what NCL allows.
+
     Returns
     -------
-    fo : :class:`xarray.DataArray`:
-        The interpolated grid. If the *meta*
-        parameter is True, then the result will include named dimensions
-        matching the input array. The returned value will have the same
-        dimensions as fi, except for the rightmost two dimensions which
-        will have the same dimension sizes as the lengths of yo and xo.
-        The return type will be double if fi is double, and float
+
+    fo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        The interpolated grid. If the *meta* parameter is True, then the result will include named
+        dimensions matching the input array. The returned value will have the same dimensions as `fi`,
+        except for the rightmost two dimensions which will have the same dimension sizes as the
+        lengths of `yo` and `xo`. The return type will be double if `fi` is double, and float
         otherwise.
+
     Examples
     --------
     Example 1: Using linint2 with :class:`xarray.DataArray` input

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -91,6 +91,7 @@ def _linint2pts(xi, yi, fi, xo, yo, icycx, msg_py, shape):
     # missing value handling
     fort2py_msg(fi, msg_fort=msg_fort, msg_py=msg_py)
     fort2py_msg(fo, msg_fort=msg_fort, msg_py=msg_py)
+
     return fo
 
 
@@ -278,6 +279,9 @@ def linint1(fi: supported_types,
     # If input was xarray.DataArray, convert output to xarray.DataArray as well
     if is_input_xr:
         fo = xr.DataArray(fo, attrs=fi.attrs, dims=fi.dims, coords=fo_coords)
+    # Else if input was numpy.ndarray, convert Dask output to numpy.ndarray with `.compute()
+    else:
+        fo = fo.compute()
 
     return fo
 
@@ -483,6 +487,9 @@ def linint2(fi: supported_types,
     # If input was xarray.DataArray, convert output to xarray.DataArray as well
     if is_input_xr:
         fo = xr.DataArray(fo, attrs=fi.attrs, dims=fi.dims, coords=fo_coords)
+    # Else if input was numpy.ndarray, convert Dask output to numpy.ndarray with `.compute()
+    else:
+        fo = fo.compute()
 
     return fo
 
@@ -592,60 +599,59 @@ def linint2pts(fi: supported_types,
     """
 
     # ''' Start of boilerplate
-    # If a Numpy input is given, convert it to Xarray and chunk it just
-    # with its dims
+    is_input_xr = True
+    is_already_chunked = False
+
+    # If the input is numpy.ndarray, convert it to xarray.DataArray
     if not isinstance(fi, xr.DataArray):
+
         if (xi is None) | (yi is None):
             raise CoordinateError(
-                "linint2pts: Arguments xi and yi must be provided explicitly unless fi is an xarray.DataArray."
-            )
+                "linint2pts: Arguments `xi` and `yi` must be provided explicitly unless "
+                "fi is an xarray.DataArray.")
+
+        is_input_xr = False
 
         fi = xr.DataArray(fi)
-        fi_chunk = dict([(k, v) for (k, v) in zip(list(fi.dims), list(fi.shape))
-                        ])
+        fi = fi.assign_coords({fi.dims[-1]: xi, fi.dims[-2]: yi})
 
-        fi = xr.DataArray(
-            fi.data,
-            coords={
-                fi.dims[-1]: xi,
-                fi.dims[-2]: yi,
-            },
-            dims=fi.dims,
-        ).chunk(fi_chunk)
-
-    # Xarray input
-    else:
-        # If an unchunked Xarray input is given, chunk it just with its dims
-        if (fi.chunks is None):
-            fi_chunk = dict([
-                (k, v) for (k, v) in zip(list(fi.dims), list(fi.shape))
-            ])
-            data = fi.chunk(fi_chunk)
-
+    # `xi` and `yi` should be coming from xarray input coords or assigned
+    # as coords while xarray being initiated from numpy input above
     xi = fi.coords[fi.dims[-1]]
     yi = fi.coords[fi.dims[-2]]
 
-    # Ensure the rightmost dimension of input is not chunked
-    if fi.chunks is None:
-        fi = fi.chunk()
+    # Convert 2d arrays to Xarray for inner wrapper call below if they are numpy
+    xo = xr.DataArray(xo)
+    yo = xr.DataArray(yo)
 
-    if list(fi.chunks)[-2:] != [yi.shape, xi.shape]:
-        raise ChunkError(
-            "ERROR linint2pts: fi must be unchunked along the rightmost two dimensions"
-        )
+    # If input data is already chunked
+    if fi.chunks is not None:
+        is_already_chunked = True
+
+        # Ensure the rightmost dimensions of `data` are not chunked
+        if list(fi.chunks)[-2:] != [yi.shape, xi.shape]:
+            raise ChunkError(
+                "linint2pts: fi must be unchunked along the rightmost two dimensions"
+            )
 
     if xo.shape != yo.shape:
-        raise Exception("ERROR linint2pts xo and yo must be of equal length")
+        raise Exception("linint2pts xo and yo must be of equal length")
 
-    # fi data structure elements and autochunking
+    # NOTE: Auto-chunking, regardless of what chunk sizes were given by the user, seems
+    # to be explicitly needed in this function because:
+    # The Fortran routine for this function is implemented assuming it would be looped
+    # across the leftmost dimensions of the input (`fi`), i.e. on one-dimensional
+    # chunks of size that is equal to the rightmost dimension of `fi`.
+
+    # Generate chunks of {'dim_0': 1, 'dim_1': 1, ..., 'dim_n-1': yi.shape, 'dim_n': xi.shape}
     fi_chunks = list(fi.dims)
     fi_chunks[:-2] = [
         (k, 1) for (k, v) in zip(list(fi.dims)[:-2],
-                                 list(fi.chunks)[:-2])
+                                 list(fi.shape)[:-2])
     ]
     fi_chunks[-2:] = [
-        (k, v[0]) for (k, v) in zip(list(fi.dims)[-2:],
-                                    list(fi.chunks)[-2:])
+        (k, v) for (k, v) in zip(list(fi.dims)[-2:],
+                                 list(fi.shape)[-2:])
     ]
     fi_chunks = dict(fi_chunks)
     fi = fi.chunk(fi_chunks)
@@ -661,6 +667,7 @@ def linint2pts(fi: supported_types,
     fo_coords[fi.dims[-2]] = yo  # maybe replace with 'pts'
     # ''' end of boilerplate
 
+    # Inner Fortran wrapper call
     fo = map_blocks(
         _linint2pts,
         yi,
@@ -676,7 +683,14 @@ def linint2pts(fi: supported_types,
         drop_axis=[fi.ndim - 2, fi.ndim - 1],
         new_axis=[fi.ndim - 2],
     )
-    fo = xr.DataArray(fo.compute(), attrs=fi.attrs)
+
+    # If input was xarray.DataArray, convert output to xarray.DataArray as well
+    if is_input_xr:
+        fo = xr.DataArray(fo, attrs=fi.attrs)
+    # Else if input was numpy.ndarray, convert Dask output to numpy.ndarray with `.compute()
+    else:
+        fo = fo.compute()
+
     return fo
 
 

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -1,8 +1,8 @@
 import warnings
 
+from dask.array.core import map_blocks
 import numpy as np
 import xarray as xr
-from dask.array.core import map_blocks
 
 from .errors import ChunkError, CoordinateError
 from .fortran import dlinint1, dlinint2, dlinint2pts

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -487,81 +487,86 @@ def linint2(fi: supported_types,
     return fo
 
 
-def linint2pts(fi, xo, yo, icycx=False, msg_py=None, xi=None, yi=None):
+def linint2pts(fi: supported_types,
+               xo: supported_types,
+               yo: supported_types,
+               icycx: bool = False,
+               msg_py: np.number = None,
+               xi: supported_types = None,
+               yi: supported_types = None) -> supported_types:
     """Interpolates from a rectilinear grid to an unstructured grid or
     locations using bilinear interpolation.
 
     Parameters
     ----------
-    fi : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        An array of two or more dimensions. The two rightmost
-        dimensions (nyi x nxi) are the dimensions to be used in
-        the interpolation. If user-defined missing values are
-        present (other than NaNs), the value of `msg_py` must be
-        set appropriately.
-    xo : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the X (longitude)
-        coordinates of the unstructured grid.
-    yo : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the Y (latitude)
-        coordinates of the unstructured grid. It must be the same
-        length as `xo`.
+
+    fi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        An array of two or more dimensions. The two rightmost dimensions (nyi x nxi) are the
+        dimensions to be used in the interpolation. If user-defined missing values are present
+        (other than NaNs), the value of `msg_py` must be set appropriately.
+
+    xo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the X-coordinates of the unstructured grid.
+
+    yo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the Y-coordinates of the unstructured grid. It
+        must be the same length as `xo`.
+
     icycx : :obj:`bool`:
-        An option to indicate whether the rightmost dimension of fi
-        is cyclic. Default valus is 0. This should be set to True
-        only if you have global data, but your longitude values
-        don't quite wrap all the way around the globe. For example,
-        if your longitude values go from, say, -179.75 to 179.75,
-        or 0.5 to 359.5, then you would set this to True.
+        An option to indicate whether the rightmost dimension of `fi` is cyclic. Default valus
+        is 0. This should be set to True only if you have global data, but your longitude values
+        don't quite wrap all the way around the globe. For example, if your longitude values go
+        from, say, -179.75 to 179.75, or 0.5 to 359.5, then you would set this to True.
+
     msg_py : :obj:`numpy.number`:
-        A numpy scalar value that represent a missing value in fi.
-        This argument allows a user to use a missing value scheme
-        other than NaN or masked arrays, similar to what NCL allows.
-    xi : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A strictly monotonically increasing array that specifies
-        the X [longitude] coordinates of the `fi` array. `xi` might
-        be defined as the coordinates of `fi` when `fi` is of type
-        `xarray.DataArray`; in this case `xi` may not be explicitly
-        given as a function argument.
-    yi : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        A strictly monotonically increasing array that specifies
-        the Y [latitude] coordinates of the `fi` array. ``yi` might
-        be defined as the coordinates of `fi` when `fi` is of type
-        `xarray.DataArray`; in this case `yi` may not be explicitly
-        given as a function argument.
+        A numpy scalar value that represent a missing value in `fi`. This argument allows a user
+        to use a missing value scheme other than NaN or masked arrays, similar to what NCL allows.
+
+    xi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A strictly monotonically increasing array that specifies the X-coordinates of the `fi`
+        array. `xi` might be defined as the coordinates of `fi` when `fi` is of type
+        `xarray.DataArray`; in this case `xi` may not be explicitly given as a function argument.
+
+    yi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A strictly monotonically increasing array that specifies the Y [latitude] coordinates of
+        the `fi` array. ``yi` might be defined as the coordinates of `fi` when `fi` is of type
+        `xarray.DataArray`; in this case `yi` may not be explicitly given as a function argument.
+
     Returns
     -------
-    fo: :class:`numpy.ndarray`:
-        The returned value will have the same dimensions as `fi`,
-        except for the rightmost dimension which will have the same
-        dimension size as the length of `yo` and `xo`. The return
-        type will be double if `fi` is double, and float otherwise.
+
+    fo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        The returned value will have the same dimensions as `fi`, except for the rightmost dimension
+        which will have the same dimension size as the length of `yo` and `xo`.
+
     Description
     -----------
-        The `linint2pts` function uses bilinear interpolation to interpolate
-        from a rectilinear grid to an unstructured grid.
-        If missing values are present, then `linint2pts` will perform the
-        piecewise linear interpolation at all points possible, but will return
-        missing values at coordinates which could not be used. If one or more
-        of the four closest grid points to a particular (xo, yo) coordinate
-        pair are missing, then the return value for this coordinate pair will
-        be missing.
-        If the user inadvertently specifies output coordinates (xo, yo) that
-        are outside those of the input coordinates (xi, yi), the output value
-        at this coordinate pair will be set to missing as no extrapolation
-        is performed.
-        `linint2pts` is different from `linint2` in that `xo` and `yo` are
-        coordinate pairs, and need not be monotonically increasing. It is
-        also different in the dimensioning of the return array.
-        This function could be used if the user wanted to interpolate gridded
-        data to, say, the location of rawinsonde sites or buoy/xbt locations.
 
-        Warning: if `xi` contains longitudes, then the `xo` values must be in the
-        same range. In addition, if the `xi` values span 0 to 360, then the `xo`
-        values must also be specified in this range (i.e. -180 to 180 will not work).
+        The `linint2pts` function uses bilinear interpolation to interpolate from a rectilinear grid
+        to an unstructured grid.
+
+        If missing values are present, then `linint2pts` will perform the piecewise linear interpolation
+        at all points possible, but will return missing values at coordinates which could not be used.
+
+        If one or more of the four closest grid points to a particular (xo, yo) coordinate pair are
+        missing, then the return value for this coordinate pair will be missing.
+
+        If the user inadvertently specifies output coordinates (xo, yo) that are outside those of the
+        input coordinates (xi, yi), the output value at this coordinate pair will be set to missing as
+        no extrapolation is performed.
+
+        `linint2pts` is different from `linint2` in that `xo` and `yo` are coordinate pairs, and need
+        not be monotonically increasing. It is also different in the dimensioning of the return array.
+        This function could be used if the user wanted to interpolate gridded data to, say, the location
+        of rawinsonde sites or buoy/xbt locations.
+
+        Warning: if `xi` contains longitudes, then the `xo` values must be in the same range. In addition,
+        if the `xi` values span 0 to 360, then the `xo` values must also be specified in this range
+        (i.e. -180 to 180 will not work).
 
     Examples
     --------
+
     Example 1: Using linint2pts with :class:`xarray.DataArray` input
         .. code-block:: python
         import numpy as np

--- a/src/geocat/f2py/linint2_wrapper.py
+++ b/src/geocat/f2py/linint2_wrapper.py
@@ -1,3 +1,4 @@
+import typing
 import warnings
 
 from dask.array.core import map_blocks
@@ -7,6 +8,8 @@ import xarray as xr
 from .errors import ChunkError, CoordinateError
 from .fortran import dlinint1, dlinint2, dlinint2pts
 from .missing_values import fort2py_msg, py2fort_msg
+
+supported_types = typing.Union[xr.DataArray, np.ndarray]
 
 # Fortran Wrappers _<funcname>()
 # These wrappers are executed within dask processes (if any), and could/should
@@ -96,37 +99,31 @@ def _linint2pts(xi, yi, fi, xo, yo, icycx, msg_py, shape):
 # used for any tasks which would not benefit from parallel execution.
 
 
-def linint1(fi, xo, xi=None, icycx=0, msg_py=None):
+def linint1(fi: supported_types,
+            xo: supported_types,
+            xi: supported_types = None,
+            icycx: np.number = 0,
+            msg_py: np.number = None) -> supported_types:
     # ''' signature : fo = dlinint1(xi,fi,xo,[icycx,xmsg,iopt])
     """Interpolates from one series to another using piecewise linear
-    interpolation across the rightmost dimension.
+    interpolation across the rightmost dimension. The series may be cyclic in
+    the X direction.
 
-    linint1 uses piecewise linear interpolation to interpolate from
-    one series to another.  The series may be cyclic in the X
-    direction.
+    If missing values are present, then linint1 will perform the piecewise linear interpolation at
+    all points possible, but will return missing values at coordinates which could not be used.
 
-    If missing values are present, then linint1 will perform the
-    piecewise linear interpolation at all points possible, but
-    will return missing values at coordinates which could not
-    be used.
-
-    If any of the output coordinates xo are outside those of the
-    input coordinates xi, the fo values at those coordinates will
-    be set to missing (i.e. no extrapolation is performed).
-
+    If any of the output coordinates `xo` are outside those of the input coordinates `xi`, the
+    `fo` values at those coordinates will be set to missing (i.e. no extrapolation is performed).
 
     Parameters
     ----------
 
-    fi : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
-        An array of one or more dimensions. If xi is passed in as an
-        argument, then the size of the rightmost dimension of fi
-        must match the rightmost dimension of xi.
+    fi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        An array of one or more dimensions. If `xi` is passed in as an argument, then the size of
+        the rightmost dimension of `fi` must match the rightmost dimension of `xi`.
 
-        If missing values are present, then linint1 will perform the
-        piecewise linear interpolation at all points possible, but
-        will return missing values at coordinates which could not be
-        used.
+        If missing values are present, then `linint1` will perform the piecewise linear interpolation
+        at all points possible, but will return missing values at coordinates which could not be used.
 
         Note:
             This variable must be
@@ -134,7 +131,7 @@ def linint1(fi, xo, xi=None, icycx=0, msg_py=None):
             the dimension names to the output. Otherwise, default
             names will be used.
 
-    xo : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    xo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         A one-dimensional array that specifies the X coordinates of
         the return array. It must be strictly monotonically
         increasing or decreasing, but may be unequally spaced.
@@ -144,15 +141,15 @@ def linint1(fi, xo, xi=None, icycx=0, msg_py=None):
         coordinates will be set to missing (i.e. no extrapolation is
         performed).
 
-    xi (:class:`numpy.ndarray`):
+    xi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         An array that specifies the X coordinates of the fi array.
         Most frequently, this array is one-dimensional.  It must be
         strictly monotonically increasing or decreasing, but can be
         unequally spaced.
-        If xi is multi-dimensional, then its
-        dimensions must be the same as fi's dimensions. If it is
-        one-dimensional, its length must be the same as the rightmost
-        (fastest varying) dimension of fi.
+        If xi is multi-dimensional, then itsimensions must be the
+        same as fi's dimensions. If it isone-dimensional, its length
+        must be the same as the rightmost (fastest varying) dimension
+        of fi.
 
         Note:
             If fi is of type :class:`xarray.DataArray` and xi is
@@ -177,7 +174,7 @@ def linint1(fi, xo, xi=None, icycx=0, msg_py=None):
 
     Returns
     -------
-    fo : :class:`xarray.DataArray`:
+    fo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         The interpolated series. The returned value will have the same
         dimensions as fi, except for the rightmost dimension which
         will have the same dimension size as the length of xo.

--- a/src/geocat/f2py/moc_globe_atl_wrapper.py
+++ b/src/geocat/f2py/moc_globe_atl_wrapper.py
@@ -1,8 +1,12 @@
+import typing
+
 import numpy as np
 import xarray as xr
 
 from .fortran import mocloops
 from .missing_values import fort2py_msg, py2fort_msg
+
+supported_types = typing.Union[xr.DataArray, np.ndarray]
 
 # Fortran Wrapper _<funcname>()
 # This wrapper is executed within dask processes (if any), and could/should
@@ -51,35 +55,35 @@ def _moc_loops(lat_aux_grid, a_wvel, a_bolus, a_submeso, t_lat, rmlak, msg_py):
 # used for any tasks which would not benefit from parallel execution.
 
 
-def moc_globe_atl(lat_aux_grid,
-                  a_wvel,
-                  a_bolus,
-                  a_submeso,
-                  t_lat,
-                  rmlak,
-                  msg=None,
-                  meta=False):
+def moc_globe_atl(lat_aux_grid: supported_types,
+                  a_wvel: supported_types,
+                  a_bolus: supported_types,
+                  a_submeso: supported_types,
+                  t_lat: supported_types,
+                  rmlak: supported_types,
+                  msg: np.number = None,
+                  meta: bool = False) -> supported_types:
     """Facilitates calculating the meridional overturning circulation for the
     globe and Atlantic.
 
     Args:
 
-    lat_aux_grid : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    lat_aux_grid : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Latitude grid for transport diagnostics.
 
-    a_wvel : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    a_wvel : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Area weighted Eulerian-mean vertical velocity [TAREA*WVEL].
 
-    a_bolus : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    a_bolus : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Area weighted Eddy-induced (bolus) vertical velocity [TAREA*WISOP].
 
-    a_submeso : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    a_submeso : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Area weighted submeso vertical velocity [TAREA*WSUBM].
 
-    tlat : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    tlat : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Array of t-grid latitudes.
 
-    rmlak : :class:`xarray.DataArray` or :class:`numpy.ndarray`:
+    rmlak : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         Basin index number: [0]=Globe, [1]=Atlantic
 
     msg : :obj:`numpy.number`:
@@ -96,7 +100,7 @@ def moc_globe_atl(lat_aux_grid,
     Returns
     -------
 
-    fo : :class:`xarray.DataArray`:
+    fo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
         A multi-dimensional array of size
         [moc_comp] x [n_transport_reg] x [kdepth] x [nyaux] where:
 
@@ -104,10 +108,6 @@ def moc_globe_atl(lat_aux_grid,
         - n_transport_reg refers to the Globe and Atlantic
         - kdepth is the the number of vertical levels of the work arrays
         - nyaux is the size of the lat_aux_grid
-
-        The type of the output data will be double only if a_wvel or a_bolus or
-        a_submesa is of type double. Otherwise, the return type will be float.
-
 
     Examples
     --------
@@ -140,25 +140,24 @@ def moc_globe_atl(lat_aux_grid,
     """
 
     # ''' Start of boilerplate
+    is_input_xr = True
+
     if not isinstance(lat_aux_grid, xr.DataArray):
+        is_input_xr = False
         lat_aux_grid = xr.DataArray(lat_aux_grid)
 
-    if not isinstance(a_wvel, xr.DataArray):
-        a_wvel = xr.DataArray(a_wvel)
+    # Convert other arguments to Xarray for inner wrapper call below if they are numpy
+    a_wvel = xr.DataArray(a_wvel)
+    a_bolus = xr.DataArray(a_bolus)
+    a_submeso = xr.DataArray(a_submeso)
+    t_lat = xr.DataArray(t_lat)
+    rmlak = xr.DataArray(rmlak)
 
-    if not isinstance(a_bolus, xr.DataArray):
-        a_bolus = xr.DataArray(a_bolus)
+    fo = _moc_loops(lat_aux_grid.data, a_wvel.data, a_bolus.data,
+                    a_submeso.data, t_lat.data, rmlak.data, msg)
 
-    if not isinstance(a_submeso, xr.DataArray):
-        a_submeso = xr.DataArray(a_submeso)
-
-    if not isinstance(t_lat, xr.DataArray):
-        t_lat = xr.DataArray(t_lat)
-
-    if not isinstance(rmlak, xr.DataArray):
-        rmlak = xr.DataArray(rmlak)
-
-    fo = _moc_loops(lat_aux_grid.values, a_wvel.values, a_bolus.values,
-                    a_submeso.values, t_lat.values, rmlak.values, msg)
+    # If input was xarray.DataArray, convert output to xarray.DataArray as well
+    if is_input_xr:
+        fo = xr.DataArray(fo)
 
     return fo

--- a/src/geocat/f2py/moc_globe_atl_wrapper.py
+++ b/src/geocat/f2py/moc_globe_atl_wrapper.py
@@ -1,8 +1,6 @@
 import numpy as np
 import xarray as xr
-from dask.array.core import map_blocks
 
-from .errors import ChunkError, CoordinateError
 from .fortran import mocloops
 from .missing_values import fort2py_msg, py2fort_msg
 

--- a/src/geocat/f2py/moc_globe_atl_wrapper.py
+++ b/src/geocat/f2py/moc_globe_atl_wrapper.py
@@ -6,9 +6,9 @@ from .errors import ChunkError, CoordinateError
 from .fortran import mocloops
 from .missing_values import fort2py_msg, py2fort_msg
 
-# Dask Wrappers _<funcname>()
-# These Wrapper are executed within dask processes, and should do anything that
-# can benefit from parallel excution.
+# Fortran Wrapper _<funcname>()
+# This wrapper is executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _moc_loops(lat_aux_grid, a_wvel, a_bolus, a_submeso, t_lat, rmlak, msg_py):
@@ -48,8 +48,8 @@ def _moc_loops(lat_aux_grid, a_wvel, a_bolus, a_submeso, t_lat, rmlak, msg_py):
     return tmp_out
 
 
-# Outer Wrappers <funcname>()
-# These Wrappers are excecuted in the __main__ python process, and should be
+# Outer Wrapper <funcname>()
+# This wrapper is excecuted in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
 

--- a/src/geocat/f2py/rcm2points_wrapper.py
+++ b/src/geocat/f2py/rcm2points_wrapper.py
@@ -8,9 +8,9 @@ from geocat.f2py.missing_values import fort2py_msg, py2fort_msg
 
 from .errors import DimensionError
 
-# Dask Wrappers _<funcname>()
-# These Wrapper are executed within dask processes, and should do anything that
-# can benefit from parallel excution.
+# Fortran Wrapper _<funcname>()
+# This wrapper is executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt, shape):
@@ -30,8 +30,8 @@ def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt, shape):
     return fo
 
 
-# Outer Wrappers <funcname>()
-# These Wrappers are excecuted in the __main__ python process, and should be
+# Outer Wrapper <funcname>()
+# This wrapper is excecuted in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
 

--- a/src/geocat/f2py/rcm2points_wrapper.py
+++ b/src/geocat/f2py/rcm2points_wrapper.py
@@ -1,3 +1,5 @@
+import typing
+
 from dask.array.core import map_blocks
 import numpy as np
 import xarray as xr
@@ -6,12 +8,14 @@ from .errors import ChunkError, CoordinateError, DimensionError
 from .fortran import drcm2points
 from .missing_values import fort2py_msg, py2fort_msg
 
+supported_types = typing.Union[xr.DataArray, np.ndarray]
+
 # Fortran Wrapper _<funcname>()
 # This wrapper is executed within dask processes (if any), and could/should
 # do anything that can benefit from parallel execution.
 
 
-def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt, shape):
+def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt):
     fi = np.transpose(fi, axes=(2, 1, 0))
     lat2d = np.transpose(lat2d, axes=(1, 0))
     lon2d = np.transpose(lon2d, axes=(1, 0))
@@ -20,7 +24,7 @@ def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt, shape):
 
     fo = drcm2points(lat2d, lon2d, fi, lat1d, lon1d, xmsg=msg_fort, opt=opt)
     fo = np.asarray(fo)
-    fo = fo.reshape(shape)
+    fo = np.transpose(fo, axes=(1, 0))
 
     fort2py_msg(fi, msg_fort=msg_fort, msg_py=msg_py)
     fort2py_msg(fo, msg_fort=msg_fort, msg_py=msg_py)
@@ -28,59 +32,97 @@ def _rcm2points(lat2d, lon2d, fi, lat1d, lon1d, msg_py, opt, shape):
     return fo
 
 
+# Helper function that checks the validity of the input
+
+
+def _validity_check(lat2d, lon2d, fi, lat1d, lon1d):
+    if (lon2d is None) | (lat2d is None):
+        raise CoordinateError(
+            "rcm2points: lon2d and lat2d should always be provided")
+
+    if lat2d.shape[0] != lon2d.shape[0] or lat2d.shape[1] != lon2d.shape[1]:
+        raise DimensionError(
+            "rcm2points: The input lat/lon grids must be the same size !")
+
+    if lat1d.shape[0] != lon1d.shape[0]:
+        raise DimensionError(
+            "rcm2points: The output lat/lon grids must be same size !")
+
+    if lat2d.shape[0] < 2 or lon2d.shape[0] < 2 or lat2d.shape[
+            1] < 2 or lon2d.shape[1] < 2:
+        raise DimensionError(
+            "rcm2points: The input/output lat/lon grids must have at least 2 elements !"
+        )
+
+    if fi.ndim < 2:
+        raise DimensionError(
+            "rcm2points: fi must be at least two dimensions !\n")
+
+    if fi.shape[fi.ndim - 2] != lat2d.shape[0] or fi.shape[fi.ndim -
+                                                           1] != lon2d.shape[1]:
+        raise DimensionError(
+            "rcm2points: The rightmost dimensions of fi must be (nlat2d x nlon2d),"
+            "where nlat2d and nlon2d are the size of the lat2d/lon2d arrays !")
+
+
 # Outer Wrapper <funcname>()
 # This wrapper is excecuted in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
 
-def rcm2points(lat2d, lon2d, fi, lat1d, lon1d, opt=0, msg=None, meta=False):
+def rcm2points(lat2d: supported_types,
+               lon2d: supported_types,
+               fi: supported_types,
+               lat1d: supported_types,
+               lon1d: supported_types,
+               opt: np.number = 0,
+               msg: np.number = None,
+               meta: bool = False) -> supported_types:
     """Interpolates data on a curvilinear grid (i.e. RCM, WRF, NARR) to an
     unstructured grid.
 
     Paraemeters
     -----------
-    lat2d : :class:`numpy.ndarray`:
-        A two-dimensional array that specifies the latitudes locations
-        of fi. The latitude order must be south-to-north.
+    lat2d : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A two-dimensional array that specifies the latitudes locations of `fi`. The latitude
+        order must be south-to-north. Because this array is two-dimensional it is not an
+        associated coordinate variable of `fi`, so it should always be explicitly provided.
 
-    lon2d : :class:`numpy.ndarray`:
-        A two-dimensional array that specifies the longitude locations
-        of fi. The latitude order must be west-to-east.
+    lon2d : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A two-dimensional array that specifies the longitude locations of `fi`. The longitude
+        order must be west-to-east. Because this array is two-dimensional it is not an
+        associated coordinate variable of `fi`, so it should always be explicitly provided.
 
-    fi : :class:`numpy.ndarray`:
-        A multi-dimensional array to be interpolated. The rightmost two
-        dimensions (latitude, longitude) are the dimensions to be interpolated.
+    fi : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A multi-dimensional array to be interpolated. The rightmost two dimensions (latitude,
+        longitude) are the dimensions to be interpolated.
 
-    lat1d : :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the latitude coordinates of
-        the output locations.
+    lat1d : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the latitude coordinates of the output locations.
 
-    lon1d : :class:`numpy.ndarray`:
-        A one-dimensional array that specifies the longitude coordinates of
-        the output locations.
+    lon1d : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+        A one-dimensional array that specifies the longitude coordinates of the output locations.
 
     opt : :obj:`numpy.number`:
         opt=0 or 1 means use an inverse distance weight interpolation.
         opt=2 means use a bilinear interpolation.
 
     msg : :obj:`numpy.number`:
-        A numpy scalar value that represent a missing value in fi.
-        This argument allows a user to use a missing value scheme
-        other than NaN or masked arrays, similar to what NCL allows.
+        A numpy scalar value that represent a missing value in `fi`. This argument allows a user to
+        use a missing value scheme other than NaN or masked arrays, similar to what NCL allows.
 
     meta : :obj:`bool`:
-        If set to True and the input array is an Xarray, the metadata
-        from the input array will be copied to the output array;
-        default is False.
+        If set to True and the input array is an Xarray, the metadata from the input array will be
+        copied to the output array; default is False.
         Warning: This option is not currently supported.
 
     Returns
     -------
 
-        :class:`numpy.ndarray`: The interpolated grid. A multi-dimensional array
-        of the same size as fi except that the rightmost dimension sizes have been
-        replaced by the number of coordinate pairs (lat1dPoints, lon1dPoints).
-        Double if fi is double, otherwise float.
+        fo : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+            The interpolated grid. A multi-dimensional array of the same size as `fi` except that the
+            rightmost dimension sizes have been replaced by the number of coordinate pairs (lat1d,
+            lon1d).
 
     Description
     -----------
@@ -93,91 +135,39 @@ def rcm2points(lat2d, lon2d, fi, lat1d, lon1d, opt=0, msg=None, meta=False):
         values are allowed and no extrapolation is performed.
     """
 
-    if (lon2d is None) | (lat2d is None):
-        raise CoordinateError(
-            "rcm2points: lon2d and lat2d should always be provided")
-
-    # Basic sanity checks
-    if lat2d.shape[0] != lon2d.shape[0] or lat2d.shape[1] != lon2d.shape[1]:
-        raise DimensionError(
-            "ERROR rcm2points: The input lat/lon grids must be the same size !")
-
-    if lat1d.shape[0] != lon1d.shape[0]:
-        raise DimensionError(
-            "ERROR rcm2points: The output lat/lon grids must be same size !")
-
-    if lat2d.shape[0] < 2 or lon2d.shape[0] < 2 or lat2d.shape[
-            1] < 2 or lon2d.shape[1] < 2:
-        raise DimensionError(
-            "ERROR rcm2points: The input/output lat/lon grids must have at least 2 elements !"
-        )
-
-    if fi.ndim < 2:
-        raise DimensionError(
-            "ERROR rcm2points: fi must be at least two dimensions !\n")
-
-    if fi.shape[fi.ndim - 2] != lat2d.shape[0] or fi.shape[fi.ndim -
-                                                           1] != lon2d.shape[1]:
-        raise DimensionError(
-            "ERROR rcm2points: The rightmost dimensions of fi must be (nlat2d x nlon2d),"
-            "where nlat2d and nlon2d are the size of the lat2d/lon2d arrays !")
+    # Basic validity checks
+    _validity_check(lat2d, lon2d, fi, lat1d, lon1d)
 
     # ''' Start of boilerplate
+    is_input_xr = True
+
+    # If the input is numpy.ndarray, convert it to xarray.DataArray
     if not isinstance(fi, xr.DataArray):
-        fi = xr.DataArray(fi,)
-        fi_chunk = dict([(k, v) for (k, v) in zip(list(fi.dims), list(fi.shape))
-                        ])
+        is_input_xr = False
 
-        fi = xr.DataArray(
-            fi.data,
-            dims=fi.dims,
-        ).chunk(fi_chunk)
+        fi = xr.DataArray(fi)
 
-    # ensure rightmost dimensions of input are not chunked
-    if fi.chunks is None:
-        fi = fi.chunk()
+    # Convert 2d arrays to Xarray for inner wrapper call below if they are numpy
+    lon2d = xr.DataArray(lon2d)
+    lat2d = xr.DataArray(lat2d)
+    lon1d = xr.DataArray(lon1d)
+    lat1d = xr.DataArray(lat1d)
 
-    if list(fi.chunks)[-2:] != [(lat2d.shape[0],), (lat2d.shape[1],)]:
-        # [(lon2d.shape[0]), (lon2d.shape[1])] could also be used
-        raise ChunkError(
-            "rcm2points: fi must be unchunked along the rightmost two dimensions"
-        )
-
-    # fi data structure elements and autochunking
-    fi_chunks = list(fi.dims)
-    fi_chunks[:-2] = [
-        (k, 1) for (k, v) in zip(list(fi.dims)[:-2],
-                                 list(fi.chunks)[:-2])
-    ]
-    fi_chunks[-2:] = [
-        (k, v[0]) for (k, v) in zip(list(fi.dims)[-2:],
-                                    list(fi.chunks)[-2:])
-    ]
-    fi_chunks = dict(fi_chunks)
-    fi = fi.chunk(fi_chunks)
-
-    # fo datastructure elements
-    fo_chunks = list(fi.chunks)
-    fo_chunks[-2:] = (lon1d.shape,)
-    fo_chunks = tuple(fo_chunks)
-    fo_shape = tuple(a[0] for a in list(fo_chunks))
+    # If input data is already chunked
+    if fi.chunks is not None:
+        # Ensure last two dimensions of `fi` are not chunked
+        if list(fi.chunks)[-2:] != [(lat2d.shape[0],), (lat2d.shape[1],)]:
+            # [(lon2d.shape[0]), (lon2d.shape[1])] could also be used
+            raise ChunkError(
+                "rcm2points: fi must be unchunked along the rightmost two dimensions"
+            )
     # ''' end of boilerplate
 
-    fo = map_blocks(
-        _rcm2points,
-        lat2d,
-        lon2d,
-        fi.data,
-        lat1d,
-        lon1d,
-        msg,
-        opt,
-        fo_shape,
-        chunks=fo_chunks,
-        dtype=fi.dtype,
-        drop_axis=[fi.ndim - 2, fi.ndim - 1],
-        new_axis=[fi.ndim - 2],
-    )
+    fo = _rcm2points(lat2d.data, lon2d.data, fi.data, lat1d.data, lon1d.data,
+                     msg, opt)
 
-    fo = xr.DataArray(fo.compute(), attrs=fi.attrs)
+    # If input was xarray.DataArray, convert output to xarray.DataArray as well
+    if is_input_xr:
+        fo = xr.DataArray(fo, attrs=fi.attrs)
+
     return fo

--- a/src/geocat/f2py/rcm2points_wrapper.py
+++ b/src/geocat/f2py/rcm2points_wrapper.py
@@ -69,7 +69,12 @@ def _validity_check(lat2d, lon2d, fi, lat1d, lon1d):
 # This wrapper is excecuted in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
+# TODO: Even though this function is advertised to work on multi-dimensional arrays,
+#  it is currently only applicable to 3D-arrays due to the implementation of `_rcm2points`
 
+
+# TODO: This function requires the input to have the coordinates in the rightmost two dimensions,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def rcm2points(lat2d: supported_types,
                lon2d: supported_types,
                fi: supported_types,

--- a/src/geocat/f2py/rcm2points_wrapper.py
+++ b/src/geocat/f2py/rcm2points_wrapper.py
@@ -1,12 +1,10 @@
+from dask.array.core import map_blocks
 import numpy as np
 import xarray as xr
-from dask.array.core import map_blocks
 
-from geocat.f2py.errors import ChunkError, CoordinateError
-from geocat.f2py.fortran import drcm2points
-from geocat.f2py.missing_values import fort2py_msg, py2fort_msg
-
-from .errors import DimensionError
+from .errors import ChunkError, CoordinateError, DimensionError
+from .fortran import drcm2points
+from .missing_values import fort2py_msg, py2fort_msg
 
 # Fortran Wrapper _<funcname>()
 # This wrapper is executed within dask processes (if any), and could/should

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -176,7 +176,7 @@ def rcm2rgrid(
 
         is_input_xr = False
 
-        fi = xr.DataArray(fi,)
+        fi = xr.DataArray(fi)
 
     # Convert 2d arrays to Xarray for inner wrapper call below if they are numpy
     lon2d = xr.DataArray(lon2d)

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -322,7 +322,7 @@ def rgrid2rcm(
     lon1d = fi.coords[fi.dims[-1]]
     lat1d = fi.coords[fi.dims[-2]]
 
-    # Convert 2d arrays to Xarray for map_blocks call below if they are numpy
+    # Convert 2d arrays to Xarray for inner wrapper call below if they are numpy
     lat2d = xr.DataArray(lat2d)
     lon2d = xr.DataArray(lon2d)
 

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -198,8 +198,8 @@ def rcm2rgrid(
     if is_input_xr:
         # Determine the output coordinates
         fo_coords = {k: v for (k, v) in fi.coords.items()}
-        fo_coords[fi.dims[-1]] = lon1d
-        fo_coords[fi.dims[-2]] = lat1d
+        fo_coords[fi.dims[-1]] = lon1d.data
+        fo_coords[fi.dims[-2]] = lat1d.data
 
         fo = xr.DataArray(fo, attrs=fi.attrs, dims=fi.dims, coords=fo_coords)
 

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -53,6 +53,8 @@ def _rgrid2rcm(lat1d, lon1d, fi, lat2d, lon2d, msg_py):
 # used for any tasks which would not benefit from parallel execution.
 
 
+# TODO: Even though this function is advertised to work on multi-dimensional arrays,
+# it is currently only applicable to 3D-arrays due to the implementation of `_rcm2rgrid`
 def rcm2rgrid(
     lat2d: supported_types,
     lon2d: supported_types,
@@ -206,6 +208,12 @@ def rcm2rgrid(
     return fo
 
 
+# TODO: Even though this function is advertised to work on multi-dimensional arrays,
+#  it is currently only applicable to 3D-arrays due to the implementation of `_rcm2rgrid`
+
+
+# TODO: This function requires the input to have the coordinates in the rightmost two dimensions,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def rgrid2rcm(
     lat1d: supported_types,
     lon1d: supported_types,

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -326,8 +326,9 @@ def rgrid2rcm(
     lat2d = xr.DataArray(lat2d)
     lon2d = xr.DataArray(lon2d)
 
-    # Ensure last two dimensions of `fi` are not chunked
+    # If input data is already chunked
     if fi.chunks is not None:
+        # Ensure last two dimensions of `fi` are not chunked
         if list(fi.chunks)[-2:] != [lat1d.shape, lon1d.shape]:
             raise Exception(
                 "rgrid2rcm: `fi` must be unchunked along the last two dimensions"

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -1,16 +1,17 @@
 import typing
+
 import numpy as np
 import xarray as xr
-from dask.array.core import map_blocks
 
 from .errors import ChunkError, CoordinateError
 from .fortran import drcm2rgrid, drgrid2rcm
 from .missing_values import fort2py_msg, py2fort_msg
 
-# Dask Wrappers _<funcname>()
-# These Wrapper are executed within dask processes, and should do anything that
-# can benefit from parallel excution.
 supported_types = typing.Union[xr.DataArray, np.ndarray]
+
+# Fortran Wrappers _<funcname>()
+# These wrappers are executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _rcm2rgrid(lat2d, lon2d, fi, lat1d, lon1d, msg_py):
@@ -48,7 +49,7 @@ def _rgrid2rcm(lat1d, lon1d, fi, lat2d, lon2d, msg_py):
 
 
 # Outer Wrappers <funcname>()
-# These Wrappers are excecuted in the __main__ python process, and should be
+# These wrappers are executed in the __main__ python process, and should be
 # used for any tasks which would not benefit from parallel execution.
 
 

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -176,6 +176,12 @@ def rcm2rgrid(
 
         fi = xr.DataArray(fi,)
 
+    # Convert 2d arrays to Xarray for inner wrapper call below if they are numpy
+    lon2d = xr.DataArray(lon2d)
+    lat2d = xr.DataArray(lat2d)
+    lon1d = xr.DataArray(lon1d)
+    lat1d = xr.DataArray(lat1d)
+
     # Ensure last two dimensions of `fi` are not chunked
     if fi.chunks is not None:
         if list(fi.chunks)[-2:] != [(lat2d.shape[0],), (lat2d.shape[1],)]:
@@ -185,7 +191,8 @@ def rcm2rgrid(
     # ''' end of boilerplate
 
     # Inner Fortran wrapper call
-    fo = _rcm2rgrid(lat2d, lon2d, fi.data, lat1d, lon1d, msg)
+    fo = _rcm2rgrid(lat2d.data, lon2d.data, fi.data, lat1d.data, lon1d.data,
+                    msg)
 
     # If input was xarray.DataArray, convert output to xarray.DataArray as well
     if is_input_xr:
@@ -336,7 +343,8 @@ def rgrid2rcm(
     # ''' end of boilerplate
 
     # Inner Fortran wrapper call
-    fo = _rgrid2rcm(lat1d, lon1d, fi.data, lat2d.data, lon2d.data, msg)
+    fo = _rgrid2rcm(lat1d.data, lon1d.data, fi.data, lat2d.data, lon2d.data,
+                    msg)
 
     # If input was xarray.DataArray, convert output to xarray.DataArray as well
     if is_input_xr:

--- a/src/geocat/f2py/rcm2rgrid_wrapper.py
+++ b/src/geocat/f2py/rcm2rgrid_wrapper.py
@@ -330,7 +330,8 @@ def rgrid2rcm(
     if fi.chunks is not None:
         if list(fi.chunks)[-2:] != [lat1d.shape, lon1d.shape]:
             raise Exception(
-                "fi must be unchunked along the last two dimensions")
+                "rgrid2rcm: `fi` must be unchunked along the last two dimensions"
+            )
     # ''' end of boilerplate
 
     # Inner Fortran wrapper call

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -1,5 +1,6 @@
 import typing
 import warnings
+
 import numpy as np
 import xarray as xr
 from dask.array.core import map_blocks
@@ -9,10 +10,11 @@ from .fortran import grid2triple as grid2triple_fort
 from .fortran import triple2grid1
 from .missing_values import fort2py_msg, py2fort_msg
 
-# Dask Wrappers or Internal Wrappers _<funcname>()
-# These Wrapper are executed within dask processes, and should do anything that
-# can benefit from parallel excution.
 supported_types = typing.Union[xr.DataArray, np.ndarray]
+
+# Fortran Wrappers _<funcname>()
+# These wrappers are executed within dask processes (if any), and could/should
+# do anything that can benefit from parallel execution.
 
 
 def _grid_to_triple(x, y, z, msg_py):

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -1,9 +1,9 @@
 import typing
 import warnings
 
+from dask.array.core import map_blocks
 import numpy as np
 import xarray as xr
-from dask.array.core import map_blocks
 
 from .errors import ChunkError, CoordinateError, DimensionError
 from .fortran import grid2triple as grid2triple_fort

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -394,7 +394,7 @@ def triple_to_grid(
     if np.asarray(domain).size != 1:
         raise ValueError("triple_to_grid: Provide a scalar value for `domain`!")
 
-    # If input data is chunked
+    # If input data is already chunked
     if data.chunks is not None:
 
         # Ensure the rightmost dimension of `data` is not chunked
@@ -423,7 +423,7 @@ def triple_to_grid(
     data_chunks = dict(data_chunks)
     data = data.chunk(data_chunks)
 
-    # grid datastructure elements
+    # grid data structure elements
     grid_chunks = list(data.chunks)
     grid_chunks[-1] = (y_out.shape[0] * x_out.shape[0],)
     grid_chunks = tuple(grid_chunks)

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -91,6 +91,8 @@ def _triple_to_grid_2d(x_in, y_in, data, x_out, y_out, msg_py):
 # used for any tasks which would not benefit from parallel execution.
 
 
+# TODO: This function requires the input to have the coordinates in a particular order,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def grid_to_triple(
     data: supported_types,
     x_in: supported_types = None,
@@ -210,6 +212,8 @@ def grid_to_triple(
     return out
 
 
+# TODO: This function requires the input to have the coordinates in the rightmost two dimensions,
+#  but xarray.DataArrray inputs with coordinates anywhere could/should actually be fine
 def triple_to_grid(
     data: supported_types,
     x_in: supported_types,

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -468,6 +468,9 @@ def triple_to_grid(
     # If input was xarray.DataArray, convert output to xarray.DataArray as well
     if is_input_xr:
         grid = xr.DataArray(grid)
+    # Else if input was numpy.ndarray, convert Dask output to numpy.ndarray with `.compute()
+    else:
+        grid = grid.compute()
 
     return grid
 

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -472,12 +472,8 @@ def triple_to_grid(
 
 # TODO: Revisit for implementing this function after deprecating geocat.ncomp
 def triple_to_grid_2d(x_in, y_in, data, x_out, y_out, msg_py):
-    warnings.warn(
-        "triple_to_grid_2d function name and signature will be deprecated soon "
-        "in a future version. Use `grid_to_triple` instead!",
-        PendingDeprecationWarning)
 
-    return triple_to_grid(data, x_in, y_in, x_out, y_out, missing_value=msg_py)
+    warnings.warn("triple_to_grid_2d function not yet implemented!!! ")
 
 
 # Transparent wrappers for geocat.ncomp backwards compatibility

--- a/test/test_dpres_plevel.py
+++ b/test/test_dpres_plevel.py
@@ -110,24 +110,44 @@ class Test_dpres_plevel_float64_psfc_scalar(ut.TestCase):
 
     def test_dpres_plevel_float64(self):
         result_dp = dpres_plevel(pressure_levels, pressure_surface_scalar)
-        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp)
+
+    def test_dpres_plevel_float64_xr(self):
+        result_dp = dpres_plevel(xr.DataArray(pressure_levels),
+                                 pressure_surface_scalar)
+        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp)
+
+    def test_dpres_plevel_float64_xr_chunked(self):
+        result_dp = dpres_plevel(
+            xr.DataArray(pressure_levels).chunk(), pressure_surface_scalar)
+        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp)
 
 
 class Test_dpres_plevel_float64_psfc_2d(ut.TestCase):
 
     def test_dpres_plevel_float64(self):
         result_dp = dpres_plevel(pressure_levels, pressure_surface_2d)
-        nt.assert_array_equal(expected_dp_psfc_2d, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_2d, result_dp)
+
+    def test_dpres_plevel_float64_xr(self):
+        result_dp = dpres_plevel(xr.DataArray(pressure_levels),
+                                 pressure_surface_2d)
+        nt.assert_array_equal(expected_dp_psfc_2d, result_dp)
+
+    def test_dpres_plevel_float64_xr_chunked(self):
+        result_dp = dpres_plevel(
+            xr.DataArray(pressure_levels).chunk(), pressure_surface_2d)
+        nt.assert_array_equal(expected_dp_psfc_2d, result_dp)
 
     def test_dpres_plevel_float64_msg_nan(self):
         result_dp = dpres_plevel(pressure_levels, pressure_surface_2d_nan)
-        nt.assert_array_equal(expected_dp_psfc_2d_msg_nan, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_2d_msg_nan, result_dp)
 
     def test_dpres_plevel_float64_msg_99(self):
         result_dp = dpres_plevel(pressure_levels,
                                  pressure_surface_2d_msg,
                                  msg_py=-99.0)
-        nt.assert_array_equal(expected_dp_psfc_2d_msg_99, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_2d_msg_99, result_dp)
 
 
 class Test_dpres_plevel_float32_psfc_scalar(ut.TestCase):
@@ -135,7 +155,7 @@ class Test_dpres_plevel_float32_psfc_scalar(ut.TestCase):
     def test_dpres_plevel_float32(self):
         plev_asfloat32 = pressure_levels.astype(np.float32)
         result_dp = dpres_plevel(plev_asfloat32, pressure_surface_scalar)
-        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_scalar, result_dp)
 
 
 class Test_dpres_plevel_float32_psfc_2d(ut.TestCase):
@@ -143,17 +163,16 @@ class Test_dpres_plevel_float32_psfc_2d(ut.TestCase):
     def test_dpres_plevel_float32(self):
         result_dp = dpres_plevel(pressure_levels_asfloat32,
                                  pressure_surface_2d_asfloat32)
-        nt.assert_array_equal(expected_dp_psfc_2d, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_2d, result_dp)
 
     def test_dpres_plevel_float32_msg_nan(self):
         result_dp = dpres_plevel(pressure_levels_asfloat32,
                                  pressure_surface_2d_nan_asfloat32)
-        asd = np.sum(result_dp.values != expected_dp_psfc_2d_msg_nan)
-        nt.assert_array_almost_equal(expected_dp_psfc_2d_msg_nan,
-                                     result_dp.values)
+        asd = np.sum(result_dp != expected_dp_psfc_2d_msg_nan)
+        nt.assert_array_almost_equal(expected_dp_psfc_2d_msg_nan, result_dp)
 
     def test_dpres_plevel_float32_msg_99(self):
         result_dp = dpres_plevel(pressure_levels_asfloat32,
                                  pressure_surface_2d_msg_asfloat32,
                                  msg_py=-99)
-        nt.assert_array_equal(expected_dp_psfc_2d_msg_99, result_dp.values)
+        nt.assert_array_equal(expected_dp_psfc_2d_msg_99, result_dp)

--- a/test/test_linint2.py
+++ b/test/test_linint2.py
@@ -240,7 +240,7 @@ class Test_linint2_numpy(ut.TestCase):
 
     def test_linint2_fi_np(self):
         fo = linint2(fi_np, xo, yo, xi=xi, yi=yi)
-        np.testing.assert_array_equal(fi_np, fo[..., ::2, ::2].values)
+        np.testing.assert_array_equal(fi_np, fo[..., ::2, ::2])
 
     def test_linint2_fi_np_no_xi_yi(self):
         with self.assertRaises(CoordinateError):
@@ -302,4 +302,4 @@ class Test_linint2_non_contiguous(ut.TestCase):
                      xi=xi,
                      yi=yi_reverse[::-1])
         np.testing.assert_array_equal(fi[:, :, ::-1, :].values,
-                                      fo[..., ::2, ::2].values)
+                                      fo[..., ::2, ::2])

--- a/test/test_linint2.py
+++ b/test/test_linint2.py
@@ -301,5 +301,4 @@ class Test_linint2_non_contiguous(ut.TestCase):
                      yo,
                      xi=xi,
                      yi=yi_reverse[::-1])
-        np.testing.assert_array_equal(fi[:, :, ::-1, :].values,
-                                      fo[..., ::2, ::2])
+        np.testing.assert_array_equal(fi[:, :, ::-1, :], fo[..., ::2, ::2])

--- a/test/test_linint2pts.py
+++ b/test/test_linint2pts.py
@@ -102,7 +102,7 @@ class Test_linint2pts_numpy(ut.TestCase, BaseTestClass):
 
         newshape = (self._shape0 * self._shape1 * self._no,)
 
-        fo_vals = fo.values.reshape(newshape).tolist()
+        fo_vals = fo.reshape(newshape)
 
         print(
             self._fi_np.reshape(
@@ -164,6 +164,29 @@ class Test_linint2pts_float64(ut.TestCase, BaseTestClass):
                               'lat': self._yi,
                               'lon': self._xi
                           }).chunk(self._chunks)
+
+        fo = linint2pts(fi, self._xo, self._yo, 0)
+
+        self.assertEqual((self._shape0, self._shape1), fo.shape[:-1])
+
+        self.assertEqual(np.float64, fo.dtype)
+
+        newshape = (self._shape0 * self._shape1 * self._no,)
+
+        fo_vals = fo.values.reshape(newshape).tolist()
+
+        # Use numpy.testing.assert_almost_equal() instead of ut.TestCase.assertAlmostEqual() because the former can
+        # handle NaNs but the latter cannot.
+        # Compare the function-generated fo array to NCL ground-truth up to 5 decimal points
+        np.testing.assert_almost_equal(self._ncl_truth, fo_vals, decimal=5)
+
+    def test_linint2pts_unchunked(self):
+        fi = xr.DataArray(self._fi_np,
+                          dims=['time', 'level', 'lat', 'lon'],
+                          coords={
+                              'lat': self._yi,
+                              'lon': self._xi
+                          })
 
         fo = linint2pts(fi, self._xo, self._yo, 0)
 

--- a/test/test_rcm2points.py
+++ b/test/test_rcm2points.py
@@ -168,3 +168,18 @@ class Test_rcm2points(ut.TestCase):
                        lon,
                        opt=2,
                        msg=msg32))
+
+
+class Test_rcm2points_xr(ut.TestCase):
+    """Test_rcm2points This unit test covers the nominal, nan, and msg cases of
+    64 and 32 bit float input for rcm2point for xarray.DataArray inputs."""
+
+    def test_rcm2points_float64_nom_opt0(self):
+        nt.assert_array_almost_equal(
+            xr.DataArray(fo_nom_opt0_expected),
+            rcm2points(lat2d,
+                       lon2d,
+                       xr.DataArray(fi_nom.astype(np.float64)),
+                       lat,
+                       lon,
+                       opt=0))

--- a/test/test_rcm2points.py
+++ b/test/test_rcm2points.py
@@ -78,96 +78,139 @@ class Test_rcm2points(ut.TestCase):
     64 and 32 bit float input for rcm2points."""
 
     def test_rcm2points_float64_nom_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_nom_opt0_expected,
-            rcm2points(lat2d, lon2d, fi_nom.astype(np.float64), lat, lon,
-                       opt=0))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nom.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=0)
+
+        nt.assert_array_almost_equal(fo, fo_nom_opt0_expected)
 
     def test_rcm2points_float64_nom_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_nom_opt2_expected,
-            rcm2points(lat2d, lon2d, fi_nom.astype(np.float64), lat, lon,
-                       opt=2))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nom.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=2)
+        nt.assert_array_almost_equal(fo, fo_nom_opt2_expected)
 
     def test_rcm2points_float64_nan_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_nan_opt0_expected,
-            rcm2points(lat2d, lon2d, fi_nan.astype(np.float64), lat, lon,
-                       opt=0))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nan.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=0)
+
+        nt.assert_array_almost_equal(fo, fo_nan_opt0_expected)
 
     def test_rcm2points_float64_nan_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_nan_opt2_expected,
-            rcm2points(lat2d, lon2d, fi_nan.astype(np.float64), lat, lon,
-                       opt=2))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nan.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=2)
+
+        nt.assert_array_almost_equal(fo, fo_nan_opt2_expected)
 
     def test_rcm2points_float64_msg_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_msg_opt0_expected,
-            rcm2points(lat2d,
-                       lon2d,
-                       fi_msg.astype(np.float64),
-                       lat,
-                       lon,
-                       opt=0,
-                       msg=msg64))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_msg.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=0,
+                        msg=msg64)
+
+        nt.assert_array_almost_equal(fo, fo_msg_opt0_expected)
 
     def test_rcm2points_float64_msg_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_msg_opt2_expected,
-            rcm2points(lat2d,
-                       lon2d,
-                       fi_msg.astype(np.float64),
-                       lat,
-                       lon,
-                       opt=2,
-                       msg=msg64))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_msg.astype(np.float64),
+                        lat,
+                        lon,
+                        opt=2,
+                        msg=msg64)
+
+        nt.assert_array_almost_equal(fo, fo_msg_opt2_expected)
 
     def test_rcm2points_float32_nom_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_nom_opt0_expected,
-            rcm2points(lat2d, lon2d, fi_nom.astype(np.float32), lat, lon,
-                       opt=0))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nom.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=0)
+
+        nt.assert_array_almost_equal(fo, fo_nom_opt0_expected)
 
     def test_rcm2points_float32_nom_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_nom_opt2_expected,
-            rcm2points(lat2d, lon2d, fi_nom.astype(np.float32), lat, lon,
-                       opt=2))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nom.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=2)
+
+        nt.assert_array_almost_equal(fo, fo_nom_opt2_expected)
 
     def test_rcm2points_float32_nan_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_nan_opt0_expected,
-            rcm2points(lat2d, lon2d, fi_nan.astype(np.float32), lat, lon,
-                       opt=0))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nan.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=0)
+
+        nt.assert_array_almost_equal(fo, fo_nan_opt0_expected)
 
     def test_rcm2points_float32_nan_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_nan_opt2_expected,
-            rcm2points(lat2d, lon2d, fi_nan.astype(np.float32), lat, lon,
-                       opt=2))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_nan.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=2)
+
+        nt.assert_array_almost_equal(fo, fo_nan_opt2_expected)
 
     def test_rcm2points_float32_msg_opt0(self):
-        nt.assert_array_almost_equal(
-            fo_msg_opt0_expected,
-            rcm2points(lat2d,
-                       lon2d,
-                       fi_msg.astype(np.float32),
-                       lat,
-                       lon,
-                       opt=0,
-                       msg=msg32))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_msg.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=0,
+                        msg=msg32)
+
+        nt.assert_array_almost_equal(fo, fo_msg_opt0_expected)
 
     def test_rcm2points_float32_msg_opt2(self):
-        nt.assert_array_almost_equal(
-            fo_msg_opt2_expected,
-            rcm2points(lat2d,
-                       lon2d,
-                       fi_msg.astype(np.float32),
-                       lat,
-                       lon,
-                       opt=2,
-                       msg=msg32))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        fi_msg.astype(np.float32),
+                        lat,
+                        lon,
+                        opt=2,
+                        msg=msg32)
+
+        nt.assert_array_almost_equal(fo, fo_msg_opt2_expected)
 
 
 class Test_rcm2points_xr(ut.TestCase):
@@ -175,11 +218,12 @@ class Test_rcm2points_xr(ut.TestCase):
     64 and 32 bit float input for rcm2point for xarray.DataArray inputs."""
 
     def test_rcm2points_float64_nom_opt0(self):
-        nt.assert_array_almost_equal(
-            xr.DataArray(fo_nom_opt0_expected),
-            rcm2points(lat2d,
-                       lon2d,
-                       xr.DataArray(fi_nom.astype(np.float64)),
-                       lat,
-                       lon,
-                       opt=0))
+
+        fo = rcm2points(lat2d,
+                        lon2d,
+                        xr.DataArray(fi_nom.astype(np.float64)),
+                        lat,
+                        lon,
+                        opt=0)
+
+        nt.assert_array_almost_equal(fo, xr.DataArray(fo_nom_opt0_expected))


### PR DESCRIPTION
Applies the improved boiler plate (originally in PR #80 ) to the rest of the functions in GeoCAt-f2py and adds test cases to some of the functions. Some functions were in applicable for getting rid of autochunking and map_block due to their Fortran routines' implementations; a descriptive comment is added to them. 