### PR TITLE
Update citation texts per Zenodo DOI implementation per-version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: "Visualization & Analysis Systems Technologies"
+title: "Geoscience Community Analysis Toolkit: GeoCAT-f2py"
+doi: 10.5281/zenodo.6654183
+url: "https://github.com/NCAR/geocat-f2py"

--- a/README.md
+++ b/README.md
@@ -62,26 +62,8 @@ intended primarily for internal use.
 
 # Citing GeoCAT-f2py
 
-NOTE: If you used GeoCAT-f2py through GeoCAT-comp, it is recommended that you cite GeoCAT-comp. Please
-refer to [GeoCAT-comp README](https://github.com/NCAR/geocat-comp#readme) for that purpose or
-[GeoCAT Citation page](https://geocat.ucar.edu/pages/citation.html) for general information about
-citing GeoCAT software packages.
-
-Hiwever, if you used GeoCAT-f2py as a standalomne software tool, cite GeoCAT-f2py using the following
-text:
-
-<> Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-f2py version \<version\>) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-Update the GeoCAT-f2py version and year as appropriate. For example:
-
-<> Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-f2py version 2021.04.0) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-For further information, please refer to
-[GeoCAT homepage - Citation](https://geocat.ucar.edu/pages/citation.html).
+If you use this software, please cite it as described at the [GeoCAT-f2py - Citation](
+https://geocat-f2py.readthedocs.io/en/latest/citation.html) page.
 
 
 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -4,17 +4,45 @@ Citation
 How to cite GeoCAT-f2py
 -----------------------
 
-Cite GeoCAT-f2py using the following text:
+NOTE: If you used GeoCAT-f2py through GeoCAT-comp, it is recommended that you cite GeoCAT-comp. Please
+refer to the `GeoCAT-comp README <https://github.com/NCAR/geocat-comp#readme>`_ or `GeoCAT-comp -
+Citation <https://geocat-comp.readthedocs.io/en/latest/citation.html>`_ pages for that purpose, and/or
+the `GeoCAT Citation page <https://geocat.ucar.edu/pages/citation.html>`_ page for general information
+about citing GeoCAT software packages.
 
-**Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-f2py version \<version\>) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+However, if you used GeoCAT-f2py as a standalone software tool, cite GeoCAT-f2py as described below:
 
-Update the GeoCAT-f2py version and year as appropriate. For example:
+Each GeoCAT-f2py version is assigned a separate Digital Object Identifier (DOI) to allow
+users to access older releases. This ensures that users are not only able to cite the specific
+software version through DOIs but are also able to download & use the corresponding release for
+reproducibility purposes.
 
-**Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-f2py version 2021.04.0) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+If you would like to cite GeoCAT-f2py as a whole (without referring to a specific version), use
+the following text:
+
+**Visualization & Analysis Systems Technologies. (2020).
+Geoscience Community Analysis Toolkit: GeoCAT-f2py [Software].
+Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6654183.**
+
+Instead, if you would like to cite a specific version of GeoCAT-f2py, use the following text:
+
+**Visualization & Analysis Systems Technologies. (\<Year\>).
+Geoscience Community Analysis Toolkit: GeoCAT-f2py (v\<version\>) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+
+In the above citation text, update the year, GeoCAT-f2py version, and DOI as appropriate. For
+example:
+
+**Visualization & Analysis Systems Technologies. (2022).
+Geoscience Community Analysis Toolkit: GeoCAT-f2py (v2022.04.0) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6654224.**
+
+Please find DOIs for all the GeoCAT-comp versions `here
+<https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226654183%22&sort=-version&all_versions=True>`_.
+
+Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
+they are the publisher of such DOIs) in their website. We prefer the text we recommend here to be used;
+however, either way is acceptable.
 
 For further information, please refer to
 `GeoCAT homepage - Citation <https://geocat.ucar.edu/pages/citation.html>`_.


### PR DESCRIPTION
We are starting to generate DOIs for each GeoCAT-comp version via the Zenodo minting service. Texts regarding citation are updated to reflect this change.