### PR TITLE
`triple_to_grid` docstring fix

### DIFF
--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -266,10 +266,7 @@ def triple_to_grid(
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.
 
-    Other Parameters
-    ----------------
-
-    method : :obj:`int`:
+    method : :obj:`int`, optional
         An integer value that can be 0 or 1. The default value is 1.
         A value of 1 means to use the great circle distance formula
         for distance calculations.
@@ -279,7 +276,7 @@ def triple_to_grid(
         high resolution grid) and the number of observations
         relatively small.
 
-    domain : :obj:`float`:
+    domain : :obj:`float`, optional
         A float value that should be set to a value >= 0. The
         default value is 1.0. If present, the larger this factor,
         the wider the spatial domain allowed to influence grid boundary
@@ -287,7 +284,7 @@ def triple_to_grid(
         then values located outside the grid domain specified by
         `x_out` and `y_out` arguments will not be used.
 
-    distmx : :obj:`float`:
+    distmx : :obj:`float`, optional
         Setting `distmx` allows the user to specify a search
         radius (km) beyond which observations are not considered
         for nearest neighbor. Only applicable when `method = 1`.
@@ -295,13 +292,13 @@ def triple_to_grid(
         will have a nearest neighbor. It is suggested that users
         specify a reasonable value for `distmx`.
 
-    missing_value : :obj:`numpy.number`:
+    missing_value : :obj:`numpy.number`, optional
         A numpy scalar value that represent
         a missing value in `data`. The default value is `np.nan`.
         If specified explicitly, this argument allows the user to
         use a missing value scheme other than NaN or masked arrays.
 
-    meta : :obj:`bool`:
+    meta : :obj:`bool`, optional
         If set to True and the input array is an Xarray,
         the metadata from the input array will be copied to the
         output array; default is False.

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -267,31 +267,31 @@ def triple_to_grid(
         values must be monotonically increasing.
 
     Other Parameters
-    -------------------
+    ----------------
 
-    method :obj:`int`:
+    method : :obj:`int`:
         An integer value that can be 0 or 1. The default value is 1.
         A value of 1 means to use the great circle distance formula
         for distance calculations.
-        Warning: `method` = 0, together with `domain` = 1.0, could
+        Warning: `method = 0`, together with `domain = 1.0`, could
         result in many of the target grid points to be set to the
         missing value if the number of grid points is large (ie: a
         high resolution grid) and the number of observations
         relatively small.
 
-    domain :obj:`float`:
+    domain : :obj:`float`:
         A float value that should be set to a value >= 0. The
         default value is 1.0. If present, the larger this factor,
         the wider the spatial domain allowed to influence grid boundary
-        points. Typically, `domain` is 1.0 or 2.0. If `domain` <= 0.0,
+        points. Typically, `domain` is 1.0 or 2.0. If `domain <= 0.0`,
         then values located outside the grid domain specified by
         `x_out` and `y_out` arguments will not be used.
 
-    distmx :obj:`float`:
+    distmx : :obj:`float`:
         Setting `distmx` allows the user to specify a search
         radius (km) beyond which observations are not considered
-        for nearest neighbor. Only applicable when `method` = 1.
-        The default `distmx`=1e20 (km) means that every grid point
+        for nearest neighbor. Only applicable when `method = 1`.
+        The default `distmx=1e20 (km)` means that every grid point
         will have a nearest neighbor. It is suggested that users
         specify a reasonable value for `distmx`.
 

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -318,7 +318,7 @@ def triple_to_grid(
     Example 1: Using triple_to_grid with :class:`xarray.DataArray` input
 
     .. code-block:: python
-    
+
         import numpy as np
         import xarray as xr
         import geocat.comp

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -248,7 +248,7 @@ def triple_to_grid(
         the "x" and "y" coordinates. Missing values may be present but
         will be ignored.
 
-    x_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
+    x_in : :class:`xarray.DataArray`, :class:`numpy.ndarray`
         A one-dimensional array that specifies the x-coordinate
         associated with the input (`data`).
 

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -242,7 +242,7 @@ def triple_to_grid(
     Parameters
     ----------
 
-    data : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
+    data : :class:`xarray.DataArray`, :class:`numpy.ndarray`
         A multi-dimensional array, whose rightmost dimension is the same
         length as `x_in` and `y_in`, containing the values associated with
         the "x" and "y" coordinates. Missing values may be present but

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -229,6 +229,16 @@ def triple_to_grid(
     """Places unstructured (randomly-spaced) data onto the nearest locations of
     a rectilinear grid.
 
+    This function puts unstructured data (randomly-spaced) onto the nearest
+    locations of a rectilinear grid. A default value of `domain` option is
+    now set to 1.0 instead of 0.0.
+
+    This function does not perform interpolation; rather, each individual
+    data point is assigned to the nearest grid point. It is possible that
+    upon return, grid will contain grid points set to missing value if
+    no `x_in(n)`, `y_in(n)` are nearby.
+
+
     Parameters
     ----------
 
@@ -256,7 +266,7 @@ def triple_to_grid(
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.
 
-    Optional Parameters
+    Other Parameters
     -------------------
 
     method :obj:`int`:
@@ -305,18 +315,6 @@ def triple_to_grid(
         dimensions of `data`, N represent the size of `y_out`,
         and M represent the size of `x_out` coordinate vectors.
 
-    Description
-    -----------
-
-        This function puts unstructured data (randomly-spaced) onto the nearest
-        locations of a rectilinear grid. A default value of `domain` option is
-        now set to 1.0 instead of 0.0.
-
-        This function does not perform interpolation; rather, each individual
-        data point is assigned to the nearest grid point. It is possible that
-        upon return, grid will contain grid points set to missing value if
-        no `x_in(n)`, `y_in(n)` are nearby.
-
     Examples
     --------
 
@@ -324,27 +322,27 @@ def triple_to_grid(
 
     .. code-block:: python
 
-        import numpy as np
-        import xarray as xr
-        import geocat.comp
+    import numpy as np
+    import xarray as xr
+    import geocat.comp
 
-        # Open a netCDF data file using xarray default engine and load the data stream
-        ds = xr.open_dataset("./ruc.nc")
+    # Open a netCDF data file using xarray default engine and load the data stream
+    ds = xr.open_dataset("./ruc.nc")
 
-        # [INPUT] Grid & data info on the source curvilinear
-        data = ds.DIST_236_CBL[:]
-        x_in = ds.gridlat_236[:]
-        y_in = ds.gridlon_236[:]
-        x_out = ds.gridlat_236[:]
-        y_out = ds.gridlon_236[:]
+    # [INPUT] Grid & data info on the source curvilinear
+    data = ds.DIST_236_CBL[:]
+    x_in = ds.gridlat_236[:]
+    y_in = ds.gridlon_236[:]
+    x_out = ds.gridlat_236[:]
+    y_out = ds.gridlon_236[:]
 
 
-        # [OUTPUT] Grid on destination points grid (or read the 1D lat and lon from
-        #              an other .nc file.
-        newlat1D_points=np.linspace(lat2D_curv.min(), lat2D_curv.max(), 100)
-        newlon1D_points=np.linspace(lon2D_curv.min(), lon2D_curv.max(), 100)
+    # [OUTPUT] Grid on destination points grid (or read the 1D lat and lon from
+    #              an other .nc file.
+    newlat1D_points=np.linspace(lat2D_curv.min(), lat2D_curv.max(), 100)
+    newlon1D_points=np.linspace(lon2D_curv.min(), lon2D_curv.max(), 100)
 
-        output = geocat.comp.triple_to_grid(data, x_out, y_out, x_in, y_in)
+    output = geocat.comp.triple_to_grid(data, x_out, y_out, x_in, y_in)
     """
 
     if (x_in is None) | (y_in is None):

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -256,7 +256,7 @@ def triple_to_grid(
         A one-dimensional array that specifies the y-coordinate
         associated with the input (`data`).
 
-    x_out : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
+    x_out : :class:`xarray.DataArray`, :class:`numpy.ndarray`
         A one-dimensional array of length M containing the x-coordinates
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -318,7 +318,6 @@ def triple_to_grid(
     Example 1: Using triple_to_grid with :class:`xarray.DataArray` input
 
     .. code-block:: python
-
         import numpy as np
         import xarray as xr
         import geocat.comp
@@ -333,13 +332,12 @@ def triple_to_grid(
         x_out = ds.gridlat_236[:]
         y_out = ds.gridlon_236[:]
 
-
         # [OUTPUT] Grid on destination points grid (or read the 1D lat and lon from
-        #              an other .nc file.
+        # another .nc file.
         newlat1D_points=np.linspace(lat2D_curv.min(), lat2D_curv.max(), 100)
         newlon1D_points=np.linspace(lon2D_curv.min(), lon2D_curv.max(), 100)
 
-        output = geocat.comp.triple_to_grid(data, x_out, y_out, x_in, y_in)
+        output = geocat.comp.triple_to_grid(data, x_in, y_in, x_out, y_out)
     """
 
     if (x_in is None) | (y_in is None):

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -261,7 +261,7 @@ def triple_to_grid(
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.
 
-    y_out : :class:`xarray.DataArray`: or :class:`numpy.ndarray`
+    y_out : :class:`xarray.DataArray` or :class:`numpy.ndarray`
         A one-dimensional array of length N containing the y-coordinates
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -252,7 +252,7 @@ def triple_to_grid(
         A one-dimensional array that specifies the x-coordinate
         associated with the input (`data`).
 
-    y_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
+    y_in : :class:`xarray.DataArray`, :class:`numpy.ndarray`
         A one-dimensional array that specifies the y-coordinate
         associated with the input (`data`).
 

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -318,6 +318,7 @@ def triple_to_grid(
     Example 1: Using triple_to_grid with :class:`xarray.DataArray` input
 
     .. code-block:: python
+    
         import numpy as np
         import xarray as xr
         import geocat.comp

--- a/src/geocat/f2py/triple_to_grid_wrapper.py
+++ b/src/geocat/f2py/triple_to_grid_wrapper.py
@@ -242,26 +242,26 @@ def triple_to_grid(
     Parameters
     ----------
 
-    data : :class:`xarray.DataArray`:, :class:`numpy.ndarray`:
+    data : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
         A multi-dimensional array, whose rightmost dimension is the same
         length as `x_in` and `y_in`, containing the values associated with
         the "x" and "y" coordinates. Missing values may be present but
         will be ignored.
 
-    x_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`:
+    x_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
         A one-dimensional array that specifies the x-coordinate
         associated with the input (`data`).
 
-    y_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`:
+    y_in : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
         A one-dimensional array that specifies the y-coordinate
         associated with the input (`data`).
 
-    x_out : :class:`xarray.DataArray`:, :class:`numpy.ndarray`:
+    x_out : :class:`xarray.DataArray`:, :class:`numpy.ndarray`
         A one-dimensional array of length M containing the x-coordinates
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.
 
-    y_out : :class:`xarray.DataArray`: or :class:`numpy.ndarray`:
+    y_out : :class:`xarray.DataArray`: or :class:`numpy.ndarray`
         A one-dimensional array of length N containing the y-coordinates
         associated with the returned two-dimensional grid. The coordinate
         values must be monotonically increasing.
@@ -307,7 +307,7 @@ def triple_to_grid(
     Returns
     -------
 
-    grid : :class:`xarray.DataArray`, :class:`numpy.ndarray`:
+    grid : :class:`xarray.DataArray`, :class:`numpy.ndarray`
         The returned array will be K x N x M, where K represents the leftmost
         dimensions of `data`, N represent the size of `y_out`,
         and M represent the size of `x_out` coordinate vectors.
@@ -319,27 +319,27 @@ def triple_to_grid(
 
     .. code-block:: python
 
-    import numpy as np
-    import xarray as xr
-    import geocat.comp
+        import numpy as np
+        import xarray as xr
+        import geocat.comp
 
-    # Open a netCDF data file using xarray default engine and load the data stream
-    ds = xr.open_dataset("./ruc.nc")
+        # Open a netCDF data file using xarray default engine and load the data stream
+        ds = xr.open_dataset("./ruc.nc")
 
-    # [INPUT] Grid & data info on the source curvilinear
-    data = ds.DIST_236_CBL[:]
-    x_in = ds.gridlat_236[:]
-    y_in = ds.gridlon_236[:]
-    x_out = ds.gridlat_236[:]
-    y_out = ds.gridlon_236[:]
+        # [INPUT] Grid & data info on the source curvilinear
+        data = ds.DIST_236_CBL[:]
+        x_in = ds.gridlat_236[:]
+        y_in = ds.gridlon_236[:]
+        x_out = ds.gridlat_236[:]
+        y_out = ds.gridlon_236[:]
 
 
-    # [OUTPUT] Grid on destination points grid (or read the 1D lat and lon from
-    #              an other .nc file.
-    newlat1D_points=np.linspace(lat2D_curv.min(), lat2D_curv.max(), 100)
-    newlon1D_points=np.linspace(lon2D_curv.min(), lon2D_curv.max(), 100)
+        # [OUTPUT] Grid on destination points grid (or read the 1D lat and lon from
+        #              an other .nc file.
+        newlat1D_points=np.linspace(lat2D_curv.min(), lat2D_curv.max(), 100)
+        newlon1D_points=np.linspace(lon2D_curv.min(), lon2D_curv.max(), 100)
 
-    output = geocat.comp.triple_to_grid(data, x_out, y_out, x_in, y_in)
+        output = geocat.comp.triple_to_grid(data, x_out, y_out, x_in, y_in)
     """
 
     if (x_in is None) | (y_in is None):


### PR DESCRIPTION
Summary of changes:
- changes to docstring structure for rtd generation
- fix of issue in parameter order in docstring example

See reported issue in geocat-comp here: https://github.com/NCAR/geocat-comp/issues/235

Note: this PR only addresses `triple_to_grid`, more docstrings should undergo similar updates