### PR TITLE
Revert "v2022.11.0"

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "geocat-f2py" %}
-{% set version = "2022.11.0" %}
+{% set version = "2022.08.0" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Reverts NCAR/geocat-f2py#114

Reverts version 2022.11.0 because there wasn't a release made during November. 
Required for the upcoming version/release 2022.12.0