### PR TITLE
Add sphinx_rtd_theme

### DIFF
--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -1,3 +1,4 @@
+name: geocat_f2py_docs
 channels:
   - conda-forge
   - ncar
@@ -8,3 +9,4 @@ dependencies:
   - dask
   - liblapack
   - sphinx-autoapi
+  - sphinx_rtd_theme


### PR DESCRIPTION
Fix sphinx theme by adding in `sphinx_rtd_theme` to conda env

Currently displaying as:
<img width="1594" height="645" alt="image" src="https://github.com/user-attachments/assets/fbb46036-eaa0-4c66-83fa-450e64614817" />

Fix displays as:
<img width="1087" height="490" alt="image" src="https://github.com/user-attachments/assets/4efb1ef8-277b-44c7-bcea-be1d9fc40cc9" />