### PR TITLE
Docs theme configuration updates

### DIFF
--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - dask
   - liblapack
   - sphinx-autoapi
-  - sphinx_rtd_theme
+  - sphinx-book-theme

--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - dask
   - liblapack
   - sphinx-autoapi
-  - sphinx-book-theme
+  - sphinx-rtd-theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,15 +168,8 @@ rst_prolog = """.. attention::
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-
-#html_theme = 'alabaster'
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if on_rtd:
-    html_theme = 'default'
-else:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+language = "en"
+html_theme = 'sphinx_book_theme'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ rst_prolog = """.. attention::
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_book_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ release = read_version()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -168,7 +168,6 @@ rst_prolog = """.. attention::
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-language = "en"
 html_theme = 'sphinx_book_theme'
 
 # The name of an image file (relative to this directory) to place at the top


### PR DESCRIPTION
Updating theme as `sphinx-book-theme`. This removes the code block with logic to handle the `html_theme` if on `READTHEDOCS`. This will always use `sphinx-book-theme`

<img width="1312" height="615" alt="image" src="https://github.com/user-attachments/assets/71fe8aed-1c20-45a9-aca5-efdcfca49bba" />
